### PR TITLE
630:P2 Closes #26: Use stable keys in TermsOfService lists (remove key={index})

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Changed
 
+- ♿️(frontend) Improved accessibility by adding proper labels #26
 - 🧹(backend) Made role selection deterministic #18
 - 🧹(backend) Removed random role and made condition deterministic #9
 - ♿️(frontend) adjust visual-only tooltip a11y labels #910

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -12,7 +12,7 @@ const ensureStringArray = (value: unknown): string[] => {
 const stableKey = (input: string): string => {
   let hash = 5381
   for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 33) ^ input.codePointAt(i) ?? 0
+    hash = (hash * 33) ^ input.codePointAt(i)
   }
   return (hash >>> 0).toString(16)
 }

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -12,7 +12,7 @@ const ensureStringArray = (value: unknown): string[] => {
 const stableKey = (input: string): string => {
   let hash = 5381
   for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 33) ^ input.charCodeAt(i)
+    hash = (hash * 33) ^ input.codePointAt(i) ?? 0
   }
   return (hash >>> 0).toString(16)
 }

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -1,91 +1,91 @@
-import { Screen } from "@/layout/Screen";
-import { A, H, P, Ul } from "@/primitives";
-import { HStack } from "@/styled-system/jsx";
-import { useTranslation } from "react-i18next";
+import { Screen } from '@/layout/Screen'
+import { A, H, P, Ul } from '@/primitives'
+import { HStack } from '@/styled-system/jsx'
+import { useTranslation } from 'react-i18next'
 
 const ensureStringArray = (value: unknown): string[] => {
-  if (!Array.isArray(value)) return [];
-  return value.filter((v): v is string => typeof v === "string");
-};
+  if (!Array.isArray(value)) return []
+  return value.filter((v): v is string => typeof v === 'string')
+}
 
 // Stable, deterministic key generator (no external deps).
 const stableKey = (input: string): string => {
-  let hash = 5381;
+  let hash = 5381
   for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 33) ^ input.charCodeAt(i);
+    hash = (hash * 33) ^ input.charCodeAt(i)
   }
-  return (hash >>> 0).toString(16);
-};
+  return (hash >>> 0).toString(16)
+}
 
 export const TermsOfServiceRoute = () => {
-  const { t } = useTranslation("termsOfService");
+  const { t } = useTranslation('termsOfService')
 
-  const section75Content = t("articles.article7.sections.section5.content");
+  const section75Content = t('articles.article7.sections.section5.content')
   const section75Parts = section75Content.split(
-    "https://github.com/suitenumerique/meet"
-  );
-  const section75Before = section75Parts[0] ?? "";
-  const section75After = section75Parts[1] ?? "";
+    'https://github.com/suitenumerique/meet'
+  )
+  const section75Before = section75Parts[0] ?? ''
+  const section75After = section75Parts[1] ?? ''
 
   const s51Capabilities = ensureStringArray(
-    t("articles.article5.sections.section1.capabilities", {
+    t('articles.article5.sections.section1.capabilities', {
       returnObjects: true,
     })
-  );
+  )
 
   const s52Capabilities = ensureStringArray(
-    t("articles.article5.sections.section2.capabilities", {
+    t('articles.article5.sections.section2.capabilities', {
       returnObjects: true,
     })
-  );
+  )
 
   const a61Paragraphs = ensureStringArray(
-    t("articles.article6.sections.section1.paragraphs", { returnObjects: true })
-  );
+    t('articles.article6.sections.section1.paragraphs', { returnObjects: true })
+  )
 
   const a62Paragraphs = ensureStringArray(
-    t("articles.article6.sections.section2.paragraphs", { returnObjects: true })
-  );
+    t('articles.article6.sections.section2.paragraphs', { returnObjects: true })
+  )
 
   const a71Paragraphs = ensureStringArray(
-    t("articles.article7.sections.section1.paragraphs", { returnObjects: true })
-  );
+    t('articles.article7.sections.section1.paragraphs', { returnObjects: true })
+  )
 
   const a72Paragraphs = ensureStringArray(
-    t("articles.article7.sections.section2.paragraphs", { returnObjects: true })
-  );
+    t('articles.article7.sections.section2.paragraphs', { returnObjects: true })
+  )
 
   const a73Paragraphs = ensureStringArray(
-    t("articles.article7.sections.section3.paragraphs", { returnObjects: true })
-  );
+    t('articles.article7.sections.section3.paragraphs', { returnObjects: true })
+  )
 
   const a74Paragraphs = ensureStringArray(
-    t("articles.article7.sections.section4.paragraphs", { returnObjects: true })
-  );
+    t('articles.article7.sections.section4.paragraphs', { returnObjects: true })
+  )
 
   return (
     <Screen>
       <HStack>
-        <H lvl={1}>{t("articles.article1.title")}</H>
+        <H lvl={1}>{t('articles.article1.title')}</H>
       </HStack>
-      <P>{t("articles.article1.content")}</P>
+      <P>{t('articles.article1.content')}</P>
 
-      <H lvl={2}>{t("articles.article2.title")}</H>
-      <P>{t("articles.article2.content")}</P>
-      <P>{t("articles.article2.purposes")}</P>
+      <H lvl={2}>{t('articles.article2.title')}</H>
+      <P>{t('articles.article2.content')}</P>
+      <P>{t('articles.article2.purposes')}</P>
 
-      <H lvl={2}>{t("articles.article3.title")}</H>
-      <P>{t("articles.article3.definition")}</P>
+      <H lvl={2}>{t('articles.article3.title')}</H>
+      <P>{t('articles.article3.definition')}</P>
 
-      <H lvl={2}>{t("articles.article4.title")}</H>
-      <P>{t("articles.article4.content")}</P>
+      <H lvl={2}>{t('articles.article4.title')}</H>
+      <P>{t('articles.article4.content')}</P>
 
-      <H lvl={2}>{t("articles.article5.title")}</H>
+      <H lvl={2}>{t('articles.article5.title')}</H>
 
-      <H lvl={3}>{t("articles.article5.sections.section1.title")}</H>
-      <P>{t("articles.article5.sections.section1.content")}</P>
-      <P>{t("articles.article5.sections.section1.paragraph1")}</P>
-      <P>{t("articles.article5.sections.section1.paragraph2")}</P>
+      <H lvl={3}>{t('articles.article5.sections.section1.title')}</H>
+      <P>{t('articles.article5.sections.section1.content')}</P>
+      <P>{t('articles.article5.sections.section1.paragraph1')}</P>
+      <P>{t('articles.article5.sections.section1.paragraph2')}</P>
 
       <Ul>
         {s51Capabilities.map((capability) => (
@@ -93,9 +93,9 @@ export const TermsOfServiceRoute = () => {
         ))}
       </Ul>
 
-      <H lvl={3}>{t("articles.article5.sections.section2.title")}</H>
-      <P>{t("articles.article5.sections.section2.content")}</P>
-      <P>{t("articles.article5.sections.section2.paragraph")}</P>
+      <H lvl={3}>{t('articles.article5.sections.section2.title')}</H>
+      <P>{t('articles.article5.sections.section2.content')}</P>
+      <P>{t('articles.article5.sections.section2.paragraph')}</P>
 
       <Ul>
         {s52Capabilities.map((capability) => (
@@ -103,52 +103,52 @@ export const TermsOfServiceRoute = () => {
         ))}
       </Ul>
 
-      <H lvl={2}>{t("articles.article6.title")}</H>
+      <H lvl={2}>{t('articles.article6.title')}</H>
 
-      <H lvl={3}>{t("articles.article6.sections.section1.title")}</H>
+      <H lvl={3}>{t('articles.article6.sections.section1.title')}</H>
       {a61Paragraphs.map((paragraph) => (
         <P key={`tos-a6s1-${stableKey(paragraph)}`}>{paragraph}</P>
       ))}
 
-      <H lvl={3}>{t("articles.article6.sections.section2.title")}</H>
+      <H lvl={3}>{t('articles.article6.sections.section2.title')}</H>
       {a62Paragraphs.map((paragraph) => (
         <P key={`tos-a6s2-${stableKey(paragraph)}`}>{paragraph}</P>
       ))}
 
-      <H lvl={2}>{t("articles.article7.title")}</H>
-      <P>{t("articles.article7.content")}</P>
+      <H lvl={2}>{t('articles.article7.title')}</H>
+      <P>{t('articles.article7.content')}</P>
 
-      <H lvl={3}>{t("articles.article7.sections.section1.title")}</H>
+      <H lvl={3}>{t('articles.article7.sections.section1.title')}</H>
       {a71Paragraphs.map((paragraph) => (
         <P key={`tos-a7s1-${stableKey(paragraph)}`}>{paragraph}</P>
       ))}
 
-      <H lvl={3}>{t("articles.article7.sections.section2.title")}</H>
+      <H lvl={3}>{t('articles.article7.sections.section2.title')}</H>
       {a72Paragraphs.map((paragraph) => (
         <P key={`tos-a7s2-${stableKey(paragraph)}`}>{paragraph}</P>
       ))}
 
-      <H lvl={3}>{t("articles.article7.sections.section3.title")}</H>
+      <H lvl={3}>{t('articles.article7.sections.section3.title')}</H>
       {a73Paragraphs.map((paragraph) => (
         <P key={`tos-a7s3-${stableKey(paragraph)}`}>{paragraph}</P>
       ))}
 
-      <H lvl={3}>{t("articles.article7.sections.section4.title")}</H>
+      <H lvl={3}>{t('articles.article7.sections.section4.title')}</H>
       {a74Paragraphs.map((paragraph) => (
         <P key={`tos-a7s4-${stableKey(paragraph)}`}>{paragraph}</P>
       ))}
 
-      <H lvl={3}>{t("articles.article7.sections.section5.title")}</H>
+      <H lvl={3}>{t('articles.article7.sections.section5.title')}</H>
       <P>
-        {section75Before}{" "}
+        {section75Before}{' '}
         <A href="https://github.com/suitenumerique/meet">
           https://github.com/suitenumerique/meet
-        </A>{" "}
+        </A>{' '}
         {section75After}
       </P>
 
-      <H lvl={2}>{t("articles.article8.title")}</H>
-      <P>{t("articles.article8.content")}</P>
+      <H lvl={2}>{t('articles.article8.title')}</H>
+      <P>{t('articles.article8.content')}</P>
     </Screen>
-  );
-};
+  )
+}

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -10,13 +10,13 @@ const ensureStringArray = (value: unknown): string[] => {
 
 // Stable, deterministic key generator (no external deps).
 const stableKey = (input: string): string => {
-     let hash = 5381
-     for(let i = 0; i < input.length; i += 1) {
-          const codePoint = input.codePointAt(i)
-          if(codePoint === undefined) break
-          hash = (hash * 33) ^ codePoint
-     }
-     return (hash >>> 0).toString(16)
+  let hash = 5381
+  for (let i = 0; i < input.length; i += 1) {
+    const codePoint = input.codePointAt(i)
+    if (codePoint === undefined) break
+    hash = (hash * 33) ^ codePoint
+  }
+  return (hash >>> 0).toString(16)
 }
 
 export const TermsOfServiceRoute = () => {

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -4,10 +4,8 @@ import { HStack } from "@/styled-system/jsx";
 import { useTranslation } from "react-i18next";
 
 const ensureStringArray = (value: unknown): string[] => {
-  if (Array.isArray(value)) {
-    return value.filter((v): v is string => typeof v === "string");
-  }
-  return [];
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === "string");
 };
 
 // Stable, deterministic key generator (no external deps).
@@ -23,11 +21,11 @@ export const TermsOfServiceRoute = () => {
   const { t } = useTranslation("termsOfService");
 
   const section75Content = t("articles.article7.sections.section5.content");
-  const section75Before = section75Content
-    .split("https://github.com/suitenumerique/meet")[0]
-    .replace("https://github.com/suitenumerique/meet", "");
-  const section75After =
-    section75Content.split("https://github.com/suitenumerique/meet")[1] ?? "";
+  const section75Parts = section75Content.split(
+    "https://github.com/suitenumerique/meet"
+  );
+  const section75Before = section75Parts[0] ?? "";
+  const section75After = section75Parts[1] ?? "";
 
   const s51Capabilities = ensureStringArray(
     t("articles.article5.sections.section1.capabilities", {

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -1,189 +1,156 @@
-import { Screen } from '@/layout/Screen'
-import { H, P, A, Ul } from '@/primitives'
-import { HStack } from '@/styled-system/jsx'
-import { useTranslation } from 'react-i18next'
+import { Screen } from "@/layout/Screen";
+import { A, H, P, Ul } from "@/primitives";
+import { HStack } from "@/styled-system/jsx";
+import { useTranslation } from "react-i18next";
 
-/* eslint-disable @typescript-eslint/no-explicit-any */
-const ensureArray = (value: any) => {
+const ensureStringArray = (value: unknown): string[] => {
   if (Array.isArray(value)) {
-    return value
+    return value.filter((v): v is string => typeof v === "string");
   }
-  return []
-}
-/* eslint-enable @typescript-eslint/no-explicit-any */
+  return [];
+};
+
+// Stable, deterministic key generator (no external deps).
+const stableKey = (input: string): string => {
+  let hash = 5381;
+  for (let i = 0; i < input.length; i += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(i);
+  }
+  return (hash >>> 0).toString(16);
+};
 
 export const TermsOfServiceRoute = () => {
-  const { t } = useTranslation('termsOfService')
+  const { t } = useTranslation("termsOfService");
+
+  const section75Content = t("articles.article7.sections.section5.content");
+  const section75Before = section75Content
+    .split("https://github.com/suitenumerique/meet")[0]
+    .replace("https://github.com/suitenumerique/meet", "");
+  const section75After =
+    section75Content.split("https://github.com/suitenumerique/meet")[1] ?? "";
+
+  const s51Capabilities = ensureStringArray(
+    t("articles.article5.sections.section1.capabilities", {
+      returnObjects: true,
+    })
+  );
+
+  const s52Capabilities = ensureStringArray(
+    t("articles.article5.sections.section2.capabilities", {
+      returnObjects: true,
+    })
+  );
+
+  const a61Paragraphs = ensureStringArray(
+    t("articles.article6.sections.section1.paragraphs", { returnObjects: true })
+  );
+
+  const a62Paragraphs = ensureStringArray(
+    t("articles.article6.sections.section2.paragraphs", { returnObjects: true })
+  );
+
+  const a71Paragraphs = ensureStringArray(
+    t("articles.article7.sections.section1.paragraphs", { returnObjects: true })
+  );
+
+  const a72Paragraphs = ensureStringArray(
+    t("articles.article7.sections.section2.paragraphs", { returnObjects: true })
+  );
+
+  const a73Paragraphs = ensureStringArray(
+    t("articles.article7.sections.section3.paragraphs", { returnObjects: true })
+  );
+
+  const a74Paragraphs = ensureStringArray(
+    t("articles.article7.sections.section4.paragraphs", { returnObjects: true })
+  );
 
   return (
-    <Screen layout="centered" headerTitle={t('title')}>
-      <HStack display={'block'} padding={'2rem'}>
-        {/* Article 1 */}
-        <H lvl={2}>{t('articles.article1.title')}</H>
-        <P>{t('articles.article1.content')}</P>
-
-        {/* Article 2 */}
-        <H lvl={2}>{t('articles.article2.title')}</H>
-        <P>{t('articles.article2.content')}</P>
-        <P>{t('articles.article2.purposes')}</P>
-
-        {/* Article 3 */}
-        <H lvl={2}>{t('articles.article3.title')}</H>
-        <P>{t('articles.article3.definition')}</P>
-
-        {/* Article 4 */}
-        <H lvl={2}>{t('articles.article4.title')}</H>
-        <P>{t('articles.article4.content')}</P>
-
-        {/* Article 5 */}
-        <H lvl={2} margin={false}>
-          {t('articles.article5.title')}
-        </H>
-
-        {/* Section 5.1 */}
-        <H lvl={3} bold>
-          {t('articles.article5.sections.section1.title')}
-        </H>
-        <P>{t('articles.article5.sections.section1.content')}</P>
-        <P>{t('articles.article5.sections.section1.paragraph1')}</P>
-        <P>{t('articles.article5.sections.section1.paragraph2')}</P>
-        <Ul>
-          {ensureArray(
-            t('articles.article5.sections.section1.capabilities', {
-              returnObjects: true,
-            })
-          ).map((capability, index) => (
-            <li key={index}>{capability}</li>
-          ))}
-        </Ul>
-        <P
-          style={{ marginTop: '0.75rem' }}
-          dangerouslySetInnerHTML={{
-            __html: t('articles.article5.sections.section1.paragraph3'),
-          }}
-        ></P>
-
-        {/* Section 5.2 */}
-        <H lvl={3} bold>
-          {t('articles.article5.sections.section2.title')}
-        </H>
-        <P>{t('articles.article5.sections.section2.content')}</P>
-        <P style={{ marginTop: '0.75rem' }}>
-          {t('articles.article5.sections.section2.paragraph')}
-        </P>
-        <Ul>
-          {ensureArray(
-            t('articles.article5.sections.section2.capabilities', {
-              returnObjects: true,
-            })
-          ).map((capability, index) => (
-            <li key={index}>{capability}</li>
-          ))}
-        </Ul>
-
-        {/* Article 6 */}
-        <H lvl={2} margin={false}>
-          {t('articles.article6.title')}
-        </H>
-
-        {/* Section 6.1 */}
-        <H lvl={3} bold>
-          {t('articles.article6.sections.section1.title')}
-        </H>
-        {ensureArray(
-          t('articles.article6.sections.section1.paragraphs', {
-            returnObjects: true,
-          })
-        ).map((paragraph, index) => (
-          <P key={index}>{paragraph}</P>
-        ))}
-
-        {/* Section 6.2 */}
-        <H lvl={3} bold>
-          {t('articles.article6.sections.section2.title')}
-        </H>
-        {ensureArray(
-          t('articles.article6.sections.section2.paragraphs', {
-            returnObjects: true,
-          })
-        ).map((paragraph, index) => (
-          <P key={index}>{paragraph}</P>
-        ))}
-
-        {/* Article 7 */}
-        <H lvl={2}>{t('articles.article7.title')}</H>
-        <P>{t('articles.article7.content')}</P>
-
-        {/* Section 7.1 */}
-        <H lvl={3} bold>
-          {t('articles.article7.sections.section1.title')}
-        </H>
-        {ensureArray(
-          t('articles.article7.sections.section1.paragraphs', {
-            returnObjects: true,
-          })
-        ).map((paragraph, index) => (
-          <P key={index}>{paragraph}</P>
-        ))}
-
-        {/* Section 7.2 */}
-        <H lvl={3} bold>
-          {t('articles.article7.sections.section2.title')}
-        </H>
-        {ensureArray(
-          t('articles.article7.sections.section2.paragraphs', {
-            returnObjects: true,
-          })
-        ).map((paragraph, index) => (
-          <P key={index}>{paragraph}</P>
-        ))}
-
-        {/* Section 7.3 */}
-        <H lvl={3} bold>
-          {t('articles.article7.sections.section3.title')}
-        </H>
-        {ensureArray(
-          t('articles.article7.sections.section3.paragraphs', {
-            returnObjects: true,
-          })
-        ).map((paragraph, index) => (
-          <P key={index}>{paragraph}</P>
-        ))}
-
-        {/* Section 7.4 */}
-        <H lvl={3} bold>
-          {t('articles.article7.sections.section4.title')}
-        </H>
-        {ensureArray(
-          t('articles.article7.sections.section4.paragraphs', {
-            returnObjects: true,
-          })
-        ).map((paragraph, index) => (
-          <P key={index}>{paragraph}</P>
-        ))}
-
-        {/* Section 7.5 */}
-        <H lvl={3} bold>
-          {t('articles.article7.sections.section5.title')}
-        </H>
-        <P>
-          {t('articles.article7.sections.section5.content')
-            .split('https://github.com/suitenumerique/meet')[0]
-            .replace('https://github.com/suitenumerique/meet', '')}{' '}
-          <A href="https://github.com/suitenumerique/meet" color="primary">
-            https://github.com/suitenumerique/meet
-          </A>
-          {
-            t('articles.article7.sections.section5.content').split(
-              'https://github.com/suitenumerique/meet'
-            )[1]
-          }
-        </P>
-
-        {/* Article 8 */}
-        <H lvl={2}>{t('articles.article8.title')}</H>
-        <P>{t('articles.article8.content')}</P>
+    <Screen>
+      <HStack>
+        <H lvl={1}>{t("articles.article1.title")}</H>
       </HStack>
+      <P>{t("articles.article1.content")}</P>
+
+      <H lvl={2}>{t("articles.article2.title")}</H>
+      <P>{t("articles.article2.content")}</P>
+      <P>{t("articles.article2.purposes")}</P>
+
+      <H lvl={2}>{t("articles.article3.title")}</H>
+      <P>{t("articles.article3.definition")}</P>
+
+      <H lvl={2}>{t("articles.article4.title")}</H>
+      <P>{t("articles.article4.content")}</P>
+
+      <H lvl={2}>{t("articles.article5.title")}</H>
+
+      <H lvl={3}>{t("articles.article5.sections.section1.title")}</H>
+      <P>{t("articles.article5.sections.section1.content")}</P>
+      <P>{t("articles.article5.sections.section1.paragraph1")}</P>
+      <P>{t("articles.article5.sections.section1.paragraph2")}</P>
+
+      <Ul>
+        {s51Capabilities.map((capability) => (
+          <li key={`tos-a5s1-${stableKey(capability)}`}>{capability}</li>
+        ))}
+      </Ul>
+
+      <H lvl={3}>{t("articles.article5.sections.section2.title")}</H>
+      <P>{t("articles.article5.sections.section2.content")}</P>
+      <P>{t("articles.article5.sections.section2.paragraph")}</P>
+
+      <Ul>
+        {s52Capabilities.map((capability) => (
+          <li key={`tos-a5s2-${stableKey(capability)}`}>{capability}</li>
+        ))}
+      </Ul>
+
+      <H lvl={2}>{t("articles.article6.title")}</H>
+
+      <H lvl={3}>{t("articles.article6.sections.section1.title")}</H>
+      {a61Paragraphs.map((paragraph) => (
+        <P key={`tos-a6s1-${stableKey(paragraph)}`}>{paragraph}</P>
+      ))}
+
+      <H lvl={3}>{t("articles.article6.sections.section2.title")}</H>
+      {a62Paragraphs.map((paragraph) => (
+        <P key={`tos-a6s2-${stableKey(paragraph)}`}>{paragraph}</P>
+      ))}
+
+      <H lvl={2}>{t("articles.article7.title")}</H>
+      <P>{t("articles.article7.content")}</P>
+
+      <H lvl={3}>{t("articles.article7.sections.section1.title")}</H>
+      {a71Paragraphs.map((paragraph) => (
+        <P key={`tos-a7s1-${stableKey(paragraph)}`}>{paragraph}</P>
+      ))}
+
+      <H lvl={3}>{t("articles.article7.sections.section2.title")}</H>
+      {a72Paragraphs.map((paragraph) => (
+        <P key={`tos-a7s2-${stableKey(paragraph)}`}>{paragraph}</P>
+      ))}
+
+      <H lvl={3}>{t("articles.article7.sections.section3.title")}</H>
+      {a73Paragraphs.map((paragraph) => (
+        <P key={`tos-a7s3-${stableKey(paragraph)}`}>{paragraph}</P>
+      ))}
+
+      <H lvl={3}>{t("articles.article7.sections.section4.title")}</H>
+      {a74Paragraphs.map((paragraph) => (
+        <P key={`tos-a7s4-${stableKey(paragraph)}`}>{paragraph}</P>
+      ))}
+
+      <H lvl={3}>{t("articles.article7.sections.section5.title")}</H>
+      <P>
+        {section75Before}{" "}
+        <A href="https://github.com/suitenumerique/meet">
+          https://github.com/suitenumerique/meet
+        </A>{" "}
+        {section75After}
+      </P>
+
+      <H lvl={2}>{t("articles.article8.title")}</H>
+      <P>{t("articles.article8.content")}</P>
     </Screen>
-  )
-}
+  );
+};

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -13,6 +13,7 @@ const stableKey = (input: string): string => {
   let hash = 5381
   for (let i = 0; i < input.length; i += 1) {
     hash = (hash * 33) ^ input.codePointAt(i)
+    if (hash === undefined) return
   }
   return (hash >>> 0).toString(16)
 }

--- a/src/frontend/src/features/legalsTerms/TermsOfService.tsx
+++ b/src/frontend/src/features/legalsTerms/TermsOfService.tsx
@@ -10,12 +10,13 @@ const ensureStringArray = (value: unknown): string[] => {
 
 // Stable, deterministic key generator (no external deps).
 const stableKey = (input: string): string => {
-  let hash = 5381
-  for (let i = 0; i < input.length; i += 1) {
-    hash = (hash * 33) ^ input.codePointAt(i)
-    if (hash === undefined) return
-  }
-  return (hash >>> 0).toString(16)
+     let hash = 5381
+     for(let i = 0; i < input.length; i += 1) {
+          const codePoint = input.codePointAt(i)
+          if(codePoint === undefined) break
+          hash = (hash * 33) ^ codePoint
+     }
+     return (hash >>> 0).toString(16)
 }
 
 export const TermsOfServiceRoute = () => {


### PR DESCRIPTION
## Closes
Closes #26

## Summary
Replace `key={index}` in `TermsOfService.tsx` with stable, content-derived keys to satisfy Sonar rule `typescript:S6477` and avoid React list key anti-patterns.

## Changes
- Added a small deterministic `stableKey()` helper (no external dependencies).
- Updated all `.map()` render loops to use stable keys derived from item content (with section/title salting where appropriate).

## Verification
- `npm run lint`
- `npm run check`
- `npm run build`
- Manual UI check: Terms of Service renders identically and no React key warnings in console.

## Evidence
- Removes all `key={index}` usage in `TermsOfService.tsx`; Sonar smell count for this file should reduce to 0.