### PR TITLE
630: P2 Closes #31: Remove redundant verbose_name/help_text for standard model fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,9 @@ and this project adheres to
 
 ### Changed
 
-- 🧹 (infra) Centralized docker compose `--user` handling (Closes #29)
-- 🔒️ (infra) Avoid writing Vaultwarden credentials (Closes #28)
+- 🧹 (backend) Remove redundant `help_text`/`verbose_name` #31
+- 🧹 (infra) Centralized docker compose `--user` handling #29
+- 🔒️ (infra) Avoid writing Vaultwarden credentials #28
 - ♿️(frontend) Refactor formatDate replace-chain #27
 - ♿️(frontend) Improved accessibility by adding proper labels #26
 - 🧹(backend) Made role selection deterministic #18

--- a/src/backend/core/migrations/0001_initial.py
+++ b/src/backend/core/migrations/0001_initial.py
@@ -25,26 +25,20 @@ class Migration(migrations.Migration):
                     models.UUIDField(
                         default=uuid.uuid4,
                         editable=False,
-                        help_text="primary key for the record as UUID",
                         primary_key=True,
                         serialize=False,
-                        verbose_name="id",
                     ),
                 ),
                 (
                     "created_at",
                     models.DateTimeField(
                         auto_now_add=True,
-                        help_text="date and time at which a record was created",
-                        verbose_name="created on",
                     ),
                 ),
                 (
                     "updated_at",
                     models.DateTimeField(
                         auto_now=True,
-                        help_text="date and time at which a record was last updated",
-                        verbose_name="updated on",
                     ),
                 ),
                 ("is_public", models.BooleanField(default=True)),
@@ -78,26 +72,20 @@ class Migration(migrations.Migration):
                     models.UUIDField(
                         default=uuid.uuid4,
                         editable=False,
-                        help_text="primary key for the record as UUID",
                         primary_key=True,
                         serialize=False,
-                        verbose_name="id",
                     ),
                 ),
                 (
                     "created_at",
                     models.DateTimeField(
                         auto_now_add=True,
-                        help_text="date and time at which a record was created",
-                        verbose_name="created on",
                     ),
                 ),
                 (
                     "updated_at",
                     models.DateTimeField(
                         auto_now=True,
-                        help_text="date and time at which a record was last updated",
-                        verbose_name="updated on",
                     ),
                 ),
                 (
@@ -257,26 +245,20 @@ class Migration(migrations.Migration):
                     models.UUIDField(
                         default=uuid.uuid4,
                         editable=False,
-                        help_text="primary key for the record as UUID",
                         primary_key=True,
                         serialize=False,
-                        verbose_name="id",
                     ),
                 ),
                 (
                     "created_at",
                     models.DateTimeField(
                         auto_now_add=True,
-                        help_text="date and time at which a record was created",
-                        verbose_name="created on",
                     ),
                 ),
                 (
                     "updated_at",
                     models.DateTimeField(
                         auto_now=True,
-                        help_text="date and time at which a record was last updated",
-                        verbose_name="updated on",
                     ),
                 ),
                 (
@@ -332,3 +314,4 @@ class Migration(migrations.Migration):
             ),
         ),
     ]
+    


### PR DESCRIPTION
## Closes
Closes #31

## Summary
Removes redundant `help_text` and `verbose_name` values from standard, self-
explanatory fields (`id`, `created_at`, `updated_at`) in the initial core
migration. This reduces boilerplate without changing schema or behavior.

## Changes
- Removed duplicated `help_text`/`verbose_name` strings from UUID primary key and
  timestamp fields across models in `0001_initial.py`.
- Preserved all functional field semantics (`uuid4` PK, auto_now_add, auto_now).

## Verification
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python -m pytest -n 2`

## Evidence
- Migration remains functionally equivalent; only metadata strings were removed,
  reducing repeated boilerplate and keeping models/migrations easier to read.