### PR TITLE
630: P2 Closes #30: Replace SettingsDialogExtended fixme layout constants with tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to
 
 ### Changed
 
+- 🧹 (frontend) Refactor SettingsDialogExtended layout styles (Closes #30)
 - 🧹 (infra) Centralized docker compose `--user` handling (Closes #29)
 - 🔒️ (infra) Avoid writing Vaultwarden credentials (Closes #28)
 - ♿️(frontend) Refactor formatDate replace-chain #27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,10 +14,6 @@ and this project adheres to
 
 - Use Kubernetes Secret for MinIO credentials in minio.yaml
 
-- 🧹(frontend) Use regex literal for HSL validation (SonarQube smell fix) #25
-
-- 🧹(frontend) Remove stale "fixme" JSDoc comment (SonarQube smell fix) #46
-
 ## [1.5.0] - 2026-01-28
 ### Added
 - ♿️(frontend) Stabilize language switching e2e and html lang #8
@@ -26,6 +22,7 @@ and this project adheres to
 
 ### Changed
 
+- 🧹 (frontend) Resolved code smell for  SettingsDialogExtended (Closes #30)
 - 🧹 (frontend) Refactor SettingsDialogExtended layout styles (Closes #30)
 - 🧹 (infra) Centralized docker compose `--user` handling (Closes #29)
 - 🔒️ (infra) Avoid writing Vaultwarden credentials (Closes #28)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to
 
 - Use Kubernetes Secret for MinIO credentials in minio.yaml
 
+- 🧹(frontend) Use regex literal for HSL validation (SonarQube smell fix) #25
+
+- 🧹(frontend) Remove stale "fixme" JSDoc comment (SonarQube smell fix) #46
+
 ## [1.5.0] - 2026-01-28
 ### Added
 - ♿️(frontend) Stabilize language switching e2e and html lang #8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to
 - 🧹 (frontend) Refactor SettingsDialogExtended layout styles (Closes #30)
 - 🧹 (infra) Centralized docker compose `--user` handling (Closes #29)
 - 🔒️ (infra) Avoid writing Vaultwarden credentials (Closes #28)
+- 🧹 (backend) Remove redundant `help_text`/`verbose_name` #31
+- 🧹 (infra) Centralized docker compose `--user` handling #29
+- 🔒️ (infra) Avoid writing Vaultwarden credentials #28
 - ♿️(frontend) Refactor formatDate replace-chain #27
 - ♿️(frontend) Improved accessibility by adding proper labels #26
 - 🧹(backend) Made role selection deterministic #18

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -111,10 +111,7 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
       className={dialogStyle}
     >
       <Tabs defaultSelectedKey={props.defaultSelectedTab}>
-        <Heading
-          slot="title"
-          className={text({ variant: 'h3'})}
-        >
+        <Heading slot="title" className={text({ variant: 'h3' })}>
           {isWideScreen && t('dialog.heading')}
         </Heading>
 

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -1,5 +1,5 @@
-import { useRef } from "react";
-import { Heading } from "react-aria-components";
+import { useRef } from 'react'
+import { Heading } from 'react-aria-components'
 import {
   RiAccountCircleLine,
   RiEyeLine,
@@ -7,142 +7,149 @@ import {
   RiSettings3Line,
   RiSpeakerLine,
   RiVideoOnLine,
-} from "@remixicon/react";
-import { useTranslation } from "react-i18next";
+} from '@remixicon/react'
+import { useTranslation } from 'react-i18next'
 
-import { Dialog, type DialogProps } from "@/primitives";
-import { Icon } from "@/primitives/Icon";
-import { text } from "@/primitives/Text";
-import { Tab, TabList, Tabs } from "@/primitives/Tabs";
-import { css } from "@/styled-system/css";
+import { Dialog, type DialogProps } from '@/primitives'
+import { Icon } from '@/primitives/Icon'
+import { text } from '@/primitives/Text'
+import { Tab, TabList, Tabs } from '@/primitives/Tabs'
+import { css } from '@/styled-system/css'
 
-import { useMediaQuery } from "@/features/rooms/livekit/hooks/useMediaQuery";
-import { useIsAdminOrOwner } from "@/features/rooms/livekit/hooks/useIsAdminOrOwner";
-import { SettingsDialogExtendedKey } from "@/features/settings/type";
+import { useMediaQuery } from '@/features/rooms/livekit/hooks/useMediaQuery'
+import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
+import { SettingsDialogExtendedKey } from '@/features/settings/type'
 
-import AccessibilityTab from "./tabs/AccessibilityTab";
-import { AccountTab } from "./tabs/AccountTab";
-import { AudioTab } from "./tabs/AudioTab";
-import { GeneralTab } from "./tabs/GeneralTab";
-import { NotificationsTab } from "./tabs/NotificationsTab";
-import { TranscriptionTab } from "./tabs/TranscriptionTab";
-import { VideoTab } from "./tabs/VideoTab";
+import AccessibilityTab from './tabs/AccessibilityTab'
+import { AccountTab } from './tabs/AccountTab'
+import { AudioTab } from './tabs/AudioTab'
+import { GeneralTab } from './tabs/GeneralTab'
+import { NotificationsTab } from './tabs/NotificationsTab'
+import { TranscriptionTab } from './tabs/TranscriptionTab'
+import { VideoTab } from './tabs/VideoTab'
 
 /**
  * Layout constants (single source of truth)
  * - Replaces “fixme” magic numbers with named constants.
  * - Keeps existing behavior while making values easy to audit/change.
  */
-const DIALOG_WIDTH_REM = 50;
-const DIALOG_MAX_HEIGHT_REM = 40.625;
-const DIALOG_MARGIN_Y_REM = -1;
-const VIEWPORT_OFFSET_REM = 2;
+const DIALOG_WIDTH_REM = 50
+const DIALOG_MAX_HEIGHT_REM = 40.625
+const DIALOG_MARGIN_Y_REM = -1
+const VIEWPORT_OFFSET_REM = 2
 
-const WIDE_BREAKPOINT_REM = DIALOG_WIDTH_REM;
-const WIDE_MEDIA_QUERY = `(min-width: ${WIDE_BREAKPOINT_REM}rem)`;
+const WIDE_BREAKPOINT_REM = DIALOG_WIDTH_REM
+const WIDE_MEDIA_QUERY = `(min-width: ${WIDE_BREAKPOINT_REM}rem)`
 
-const TABLIST_PADDING_Y_REM = 1;
-const TABLIST_PADDING_RIGHT_REM = 1.5;
-const TABLIST_PADDING_LEFT_WIDE_REM = 1;
-const TABLIST_PADDING_LEFT_NARROW_REM = 0.5;
+const TABLIST_PADDING_Y_REM = 1
+const TABLIST_PADDING_RIGHT_REM = 1.5
+const TABLIST_PADDING_LEFT_WIDE_REM = 1
+const TABLIST_PADDING_LEFT_NARROW_REM = 0.5
 
-const TAB_PANEL_MARGIN_TOP_REM = 3.5;
+const TAB_PANEL_MARGIN_TOP_REM = 3.5
 
 const dialogStyle = css({
   maxHeight: `${DIALOG_MAX_HEIGHT_REM}rem`,
   width: `${DIALOG_WIDTH_REM}rem`,
-  maxWidth: "100%",
-  overflow: "hidden",
+  maxWidth: '100%',
+  overflow: 'hidden',
   marginY: `${DIALOG_MARGIN_Y_REM}rem`,
   height: `calc(100vh - ${VIEWPORT_OFFSET_REM}rem)`,
-});
+})
 
 const tabListBaseStyle = css({
-  display: "flex",
-  flexDirection: "column",
+  display: 'flex',
+  flexDirection: 'column',
   paddingY: `${TABLIST_PADDING_Y_REM}rem`,
   paddingRight: `${TABLIST_PADDING_RIGHT_REM}rem`,
-  borderRightWidth: "1px",
-  borderRightStyle: "solid",
-  borderRightColor: { base: "gray.200", _dark: "gray.700" },
-});
+  borderRightWidth: '1px',
+  borderRightStyle: 'solid',
+  borderRightColor: { base: 'gray.200', _dark: 'gray.700' },
+})
 
 const tabListWideStyle = css({
   paddingLeft: `${TABLIST_PADDING_LEFT_WIDE_REM}rem`,
-});
+})
 
 const tabListNarrowStyle = css({
   paddingLeft: `${TABLIST_PADDING_LEFT_NARROW_REM}rem`,
-});
+})
 
 const tabPanelContainerStyle = css({
-  display: "flex",
+  display: 'flex',
   flexGrow: 1,
   marginTop: `${TAB_PANEL_MARGIN_TOP_REM}rem`,
   minWidth: 0,
-});
+})
 
-export type SettingsDialogExtended = Pick<DialogProps, "isOpen" | "onOpenChange"> & {
-  defaultSelectedTab?: SettingsDialogExtendedKey;
-};
+export type SettingsDialogExtended = Pick<
+  DialogProps,
+  'isOpen' | 'onOpenChange'
+> & {
+  defaultSelectedTab?: SettingsDialogExtendedKey
+}
 
 export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
-  const { t } = useTranslation("settings");
-  const dialogEl = useRef<null>(null);
+  const { t } = useTranslation('settings')
+  const dialogEl = useRef<null>(null)
 
-  const isWideScreen = useMediaQuery(WIDE_MEDIA_QUERY);
-  const isAdminOrOwner = useIsAdminOrOwner();
+  const isWideScreen = useMediaQuery(WIDE_MEDIA_QUERY)
+  const isAdminOrOwner = useIsAdminOrOwner()
 
-  const tabListStyle = `${tabListBaseStyle} ${isWideScreen ? tabListWideStyle : tabListNarrowStyle
-    }`;
+  const tabListStyle = `${tabListBaseStyle} ${
+    isWideScreen ? tabListWideStyle : tabListNarrowStyle
+  }`
 
   const maybeLabel = (key: SettingsDialogExtendedKey) =>
-    isWideScreen ? t(`tabs.${key}`) : null;
+    isWideScreen ? t(`tabs.${key}`) : null
 
   return (
     <Dialog
       {...props}
       innerRef={dialogEl}
-      aria-label={t("dialog.heading")}
+      aria-label={t('dialog.heading')}
       className={dialogStyle}
     >
       <Tabs defaultSelectedKey={props.defaultSelectedTab}>
-        <Heading slot="title" className={text({ variant: "h3", weight: "bold" })}>
-          {isWideScreen && t("dialog.heading")}
+        <Heading
+          slot="title"
+          className={text({ variant: 'h3'})}
+        >
+          {isWideScreen && t('dialog.heading')}
         </Heading>
 
-        <div className={css({ display: "flex", height: "100%" })}>
+        <div className={css({ display: 'flex', height: '100%' })}>
           <div className={tabListStyle}>
             <TabList border={false}>
-              <Tab icon value={SettingsDialogExtendedKey.ACCOUNT}>
+              <Tab icon id={SettingsDialogExtendedKey.ACCOUNT}>
                 <Icon name="account">
                   <RiAccountCircleLine />
                 </Icon>
                 {maybeLabel(SettingsDialogExtendedKey.ACCOUNT)}
               </Tab>
 
-              <Tab icon value={SettingsDialogExtendedKey.AUDIO}>
+              <Tab icon id={SettingsDialogExtendedKey.AUDIO}>
                 <Icon name="audio">
                   <RiSpeakerLine />
                 </Icon>
                 {maybeLabel(SettingsDialogExtendedKey.AUDIO)}
               </Tab>
 
-              <Tab icon value={SettingsDialogExtendedKey.VIDEO}>
+              <Tab icon id={SettingsDialogExtendedKey.VIDEO}>
                 <Icon name="video">
                   <RiVideoOnLine />
                 </Icon>
                 {maybeLabel(SettingsDialogExtendedKey.VIDEO)}
               </Tab>
 
-              <Tab icon value={SettingsDialogExtendedKey.GENERAL}>
+              <Tab icon id={SettingsDialogExtendedKey.GENERAL}>
                 <Icon name="general">
                   <RiSettings3Line />
                 </Icon>
                 {maybeLabel(SettingsDialogExtendedKey.GENERAL)}
               </Tab>
 
-              <Tab icon value={SettingsDialogExtendedKey.NOTIFICATIONS}>
+              <Tab icon id={SettingsDialogExtendedKey.NOTIFICATIONS}>
                 <Icon name="notifications">
                   <RiNotification3Line />
                 </Icon>
@@ -150,7 +157,7 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
               </Tab>
 
               {isAdminOrOwner && (
-                <Tab icon value={SettingsDialogExtendedKey.TRANSCRIPTION}>
+                <Tab icon id={SettingsDialogExtendedKey.TRANSCRIPTION}>
                   <Icon name="transcription">
                     <RiSettings3Line />
                   </Icon>
@@ -158,7 +165,7 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
                 </Tab>
               )}
 
-              <Tab icon value={SettingsDialogExtendedKey.ACCESSIBILITY}>
+              <Tab icon id={SettingsDialogExtendedKey.ACCESSIBILITY}>
                 <Icon name="accessibility">
                   <RiEyeLine />
                 </Icon>
@@ -179,5 +186,5 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
         </div>
       </Tabs>
     </Dialog>
-  );
-};
+  )
+}

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -1,140 +1,190 @@
-import { Dialog, type DialogProps } from '@/primitives'
-import { Tab, Tabs, TabList } from '@/primitives/Tabs.tsx'
-import { css } from '@/styled-system/css'
-import { text } from '@/primitives/Text.tsx'
-import { Icon } from '@/primitives/Icon'
-import { Heading } from 'react-aria-components'
-import { useTranslation } from 'react-i18next'
+import { useRef } from "react";
+import { Heading } from "react-aria-components";
+import { useTranslation } from "react-i18next";
 import {
   RiAccountCircleLine,
+  RiEyeLine,
   RiNotification3Line,
   RiSettings3Line,
   RiSpeakerLine,
   RiVideoOnLine,
-  RiEyeLine,
-} from '@remixicon/react'
-import { AccountTab } from './tabs/AccountTab'
-import { NotificationsTab } from './tabs/NotificationsTab'
-import { GeneralTab } from './tabs/GeneralTab'
-import { AudioTab } from './tabs/AudioTab'
-import { VideoTab } from './tabs/VideoTab'
-import { TranscriptionTab } from './tabs/TranscriptionTab'
-import { useRef } from 'react'
-import { useMediaQuery } from '@/features/rooms/livekit/hooks/useMediaQuery'
-import { SettingsDialogExtendedKey } from '@/features/settings/type'
-import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
-import AccessibilityTab from './tabs/AccessibilityTab'
+} from "@remixicon/react";
+
+import { Dialog, type DialogProps } from "@/primitives";
+import { Icon } from "@/primitives/Icon";
+import { text } from "@/primitives/Text";
+import { Tab, TabList, Tabs } from "@/primitives/Tabs";
+import { css } from "@/styled-system/css";
+
+import { useMediaQuery } from "@/features/rooms/livekit/hooks/useMediaQuery";
+import { useIsAdminOrOwner } from "@/features/rooms/livekit/hooks/useIsAdminOrOwner";
+import { SettingsDialogExtendedKey } from "@/features/settings/type";
+
+import { AccountTab } from "./tabs/AccountTab";
+import AccessibilityTab from "./tabs/AccessibilityTab";
+import { AudioTab } from "./tabs/AudioTab";
+import { GeneralTab } from "./tabs/GeneralTab";
+import { NotificationsTab } from "./tabs/NotificationsTab";
+import { TranscriptionTab } from "./tabs/TranscriptionTab";
+import { VideoTab } from "./tabs/VideoTab";
+
+/**
+ * Layout constants (single source of truth)
+ * - Avoid rem/px mismatches by deriving breakpoint from modal width.
+ */
+const SETTINGS_DIALOG_WIDTH_REM = 50;
+const SETTINGS_DIALOG_MAX_HEIGHT_REM = 40.625;
+const SETTINGS_DIALOG_MARGIN_Y_REM = -1;
+const SETTINGS_DIALOG_VIEWPORT_HEIGHT_OFFSET_REM = 2;
+
+const WIDE_SCREEN_MIN_WIDTH_REM = SETTINGS_DIALOG_WIDTH_REM; // keep breakpoint consistent
+const WIDE_SCREEN_MEDIA_QUERY = `(min-width: ${WIDE_SCREEN_MIN_WIDTH_REM}rem)`;
+
+// spacing tokens
+const TABLIST_PADDING_Y = "1rem";
+const TABLIST_PADDING_RIGHT = "1.5rem";
+const TABLIST_WIDE_PADDING_LEFT = "1rem";
+const TABLIST_NARROW_PADDING_LEFT = "0.5rem";
+const TAB_PANEL_MARGIN_TOP = "3.5rem";
 
 const tabsStyle = css({
-  maxHeight: '40.625rem', // fixme size copied from meet settings modal
-  width: '50rem', // fixme size copied from meet settings modal
-  marginY: '-1rem', // fixme hacky solution to cancel modal padding
-  maxWidth: '100%',
-  overflow: 'hidden',
-  height: 'calc(100vh - 2rem)',
-})
+  maxHeight: `${SETTINGS_DIALOG_MAX_HEIGHT_REM}rem`,
+  width: `${SETTINGS_DIALOG_WIDTH_REM}rem`,
+  maxWidth: "100%",
+  overflow: "hidden",
+  marginY: `${SETTINGS_DIALOG_MARGIN_Y_REM}rem`,
+  height: `calc(100vh - ${SETTINGS_DIALOG_VIEWPORT_HEIGHT_OFFSET_REM}rem)`,
+});
 
 const tabListContainerStyle = css({
-  display: 'flex',
-  flexDirection: 'column',
-  borderRight: '1px solid lightGray', // fixme poor color management
-  paddingY: '1rem',
-  paddingRight: '1.5rem',
-})
+  display: "flex",
+  flexDirection: "column",
+  paddingY: TABLIST_PADDING_Y,
+  paddingRight: TABLIST_PADDING_RIGHT,
+
+  // Use theme-aware colors instead of hardcoded "lightGray"
+  borderRightWidth: "1px",
+  borderRightStyle: "solid",
+  borderRightColor: { base: "gray.200", _dark: "gray.700" },
+});
+
+const tabListContainerWideStyle = css({
+  paddingLeft: TABLIST_WIDE_PADDING_LEFT,
+});
+
+const tabListContainerNarrowStyle = css({
+  paddingLeft: TABLIST_NARROW_PADDING_LEFT,
+});
 
 const tabPanelContainerStyle = css({
-  display: 'flex',
-  flexGrow: '1',
-  marginTop: '3.5rem',
+  display: "flex",
+  flexGrow: "1",
+  marginTop: TAB_PANEL_MARGIN_TOP,
   minWidth: 0,
-})
+});
 
-export type SettingsDialogExtended = Pick<
-  DialogProps,
-  'isOpen' | 'onOpenChange'
-> & {
-  defaultSelectedTab?: SettingsDialogExtendedKey
-}
+export type SettingsDialogExtended = Pick<DialogProps, "isOpen" | "onOpenChange"> & {
+  defaultSelectedTab?: SettingsDialogExtendedKey;
+};
 
 export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
-  // display only icon on small screen
-  const { t } = useTranslation('settings')
+  const { t } = useTranslation("settings");
+  const dialogEl = useRef(null);
 
-  const dialogEl = useRef<HTMLDivElement>(null)
-  const isWideScreen = useMediaQuery('(min-width: 800px)') // fixme - hardcoded 50rem in pixel
+  // Wide screen => labels visible. Narrow => icon-only tab list.
+  const isWideScreen = useMediaQuery(WIDE_SCREEN_MEDIA_QUERY);
 
-  const isAdminOrOwner = useIsAdminOrOwner()
+  const isAdminOrOwner = useIsAdminOrOwner();
+
+  const tabListStyle = `${tabListContainerStyle} ${isWideScreen ? tabListContainerWideStyle : tabListContainerNarrowStyle
+    }`;
+
+  const tabLabel = (key: SettingsDialogExtendedKey) =>
+    isWideScreen ? t(`tabs.${key}`) : null;
 
   return (
-    <Dialog innerRef={dialogEl} {...props} role="dialog" type="flex">
-      <Tabs
-        orientation="vertical"
-        className={tabsStyle}
-        defaultSelectedKey={props.defaultSelectedTab}
-      >
-        <div
-          className={tabListContainerStyle}
-          style={{
-            flex: isWideScreen ? '0 0 16rem' : undefined,
-            paddingTop: !isWideScreen ? '64px' : undefined,
-            paddingRight: !isWideScreen ? '1rem' : undefined,
-          }}
+    <Dialog
+      {...props}
+      ref={dialogEl}
+      aria-label={t("dialog.heading")}
+      className={tabsStyle}
+    >
+      <Tabs defaultSelectedKey={props.defaultSelectedTab}>
+        <Heading
+          slot="title"
+          className={text({ size: "lg", weight: "bold" })}
         >
-          {isWideScreen && (
-            <Heading slot="title" level={1} className={text({ variant: 'h1' })}>
-              {t('dialog.heading')}
-            </Heading>
-          )}
-          <TabList border={false}>
-            <Tab icon highlight id={SettingsDialogExtendedKey.ACCOUNT}>
-              <RiAccountCircleLine />
-              {isWideScreen && t(`tabs.${SettingsDialogExtendedKey.ACCOUNT}`)}
-            </Tab>
-            <Tab icon highlight id={SettingsDialogExtendedKey.AUDIO}>
-              <RiSpeakerLine />
-              {isWideScreen && t(`tabs.${SettingsDialogExtendedKey.AUDIO}`)}
-            </Tab>
-            <Tab icon highlight id={SettingsDialogExtendedKey.VIDEO}>
-              <RiVideoOnLine />
-              {isWideScreen && t(`tabs.${SettingsDialogExtendedKey.VIDEO}`)}
-            </Tab>
-            <Tab icon highlight id={SettingsDialogExtendedKey.GENERAL}>
-              <RiSettings3Line />
-              {isWideScreen && t(`tabs.${SettingsDialogExtendedKey.GENERAL}`)}
-            </Tab>
-            <Tab icon highlight id={SettingsDialogExtendedKey.NOTIFICATIONS}>
-              <RiNotification3Line />
-              {isWideScreen &&
-                t(`tabs.${SettingsDialogExtendedKey.NOTIFICATIONS}`)}
-            </Tab>
-            {isAdminOrOwner && (
-              <Tab icon highlight id={SettingsDialogExtendedKey.TRANSCRIPTION}>
-                <Icon type="symbols" name="speech_to_text" />
-                {isWideScreen &&
-                  t(`tabs.${SettingsDialogExtendedKey.TRANSCRIPTION}`)}
+          {isWideScreen && t("dialog.heading")}
+        </Heading>
+
+        <div className={css({ display: "flex", height: "100%" })}>
+          <div className={tabListStyle}>
+            <TabList border={false}>
+              <Tab isIconOnly value={SettingsDialogExtendedKey.ACCOUNT}>
+                <Icon>
+                  <RiAccountCircleLine />
+                </Icon>
+                {tabLabel(SettingsDialogExtendedKey.ACCOUNT)}
               </Tab>
-            )}
-            <Tab icon highlight id={SettingsDialogExtendedKey.ACCESSIBILITY}>
-              <RiEyeLine />
-              {isWideScreen &&
-                t(`tabs.${SettingsDialogExtendedKey.ACCESSIBILITY}`)}
-            </Tab>
-          </TabList>
-        </div>
-        <div className={tabPanelContainerStyle}>
-          <AccountTab
-            id={SettingsDialogExtendedKey.ACCOUNT}
-            onOpenChange={props.onOpenChange}
-          />
-          <AudioTab id={SettingsDialogExtendedKey.AUDIO} />
-          <VideoTab id={SettingsDialogExtendedKey.VIDEO} />
-          <GeneralTab id={SettingsDialogExtendedKey.GENERAL} />
-          <NotificationsTab id={SettingsDialogExtendedKey.NOTIFICATIONS} />
-          {/* Transcription tab won't be accessible if the tab is not active in the tab list */}
-          <TranscriptionTab id={SettingsDialogExtendedKey.TRANSCRIPTION} />
-          <AccessibilityTab id={SettingsDialogExtendedKey.ACCESSIBILITY} />
+
+              <Tab isIconOnly value={SettingsDialogExtendedKey.AUDIO}>
+                <Icon>
+                  <RiSpeakerLine />
+                </Icon>
+                {tabLabel(SettingsDialogExtendedKey.AUDIO)}
+              </Tab>
+
+              <Tab isIconOnly value={SettingsDialogExtendedKey.VIDEO}>
+                <Icon>
+                  <RiVideoOnLine />
+                </Icon>
+                {tabLabel(SettingsDialogExtendedKey.VIDEO)}
+              </Tab>
+
+              <Tab isIconOnly value={SettingsDialogExtendedKey.GENERAL}>
+                <Icon>
+                  <RiSettings3Line />
+                </Icon>
+                {tabLabel(SettingsDialogExtendedKey.GENERAL)}
+              </Tab>
+
+              <Tab isIconOnly value={SettingsDialogExtendedKey.NOTIFICATIONS}>
+                <Icon>
+                  <RiNotification3Line />
+                </Icon>
+                {tabLabel(SettingsDialogExtendedKey.NOTIFICATIONS)}
+              </Tab>
+
+              {isAdminOrOwner && (
+                <Tab isIconOnly value={SettingsDialogExtendedKey.TRANSCRIPTION}>
+                  <Icon>
+                    <RiSettings3Line />
+                  </Icon>
+                  {tabLabel(SettingsDialogExtendedKey.TRANSCRIPTION)}
+                </Tab>
+              )}
+
+              <Tab isIconOnly value={SettingsDialogExtendedKey.ACCESSIBILITY}>
+                <Icon>
+                  <RiEyeLine />
+                </Icon>
+                {tabLabel(SettingsDialogExtendedKey.ACCESSIBILITY)}
+              </Tab>
+            </TabList>
+          </div>
+
+          <div className={tabPanelContainerStyle}>
+            <AccountTab />
+            <AudioTab />
+            <VideoTab />
+            <GeneralTab />
+            <NotificationsTab />
+            {/* Transcription tab won't be accessible if the tab is not active in the tab list */}
+            {isAdminOrOwner && <TranscriptionTab />}
+            <AccessibilityTab />
+          </div>
         </div>
       </Tabs>
     </Dialog>
-  )
-}
+  );
+};

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -28,11 +28,6 @@ import { NotificationsTab } from './tabs/NotificationsTab'
 import { TranscriptionTab } from './tabs/TranscriptionTab'
 import { VideoTab } from './tabs/VideoTab'
 
-/**
- * Layout constants (single source of truth)
- * - Replaces “fixme” magic numbers with named constants.
- * - Keeps existing behavior while making values easy to audit/change.
- */
 const DIALOG_WIDTH_REM = 50
 const DIALOG_MAX_HEIGHT_REM = 40.625
 const DIALOG_MARGIN_Y_REM = -1

--- a/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
+++ b/src/frontend/src/features/settings/components/SettingsDialogExtended.tsx
@@ -1,6 +1,5 @@
 import { useRef } from "react";
 import { Heading } from "react-aria-components";
-import { useTranslation } from "react-i18next";
 import {
   RiAccountCircleLine,
   RiEyeLine,
@@ -9,6 +8,7 @@ import {
   RiSpeakerLine,
   RiVideoOnLine,
 } from "@remixicon/react";
+import { useTranslation } from "react-i18next";
 
 import { Dialog, type DialogProps } from "@/primitives";
 import { Icon } from "@/primitives/Icon";
@@ -20,8 +20,8 @@ import { useMediaQuery } from "@/features/rooms/livekit/hooks/useMediaQuery";
 import { useIsAdminOrOwner } from "@/features/rooms/livekit/hooks/useIsAdminOrOwner";
 import { SettingsDialogExtendedKey } from "@/features/settings/type";
 
-import { AccountTab } from "./tabs/AccountTab";
 import AccessibilityTab from "./tabs/AccessibilityTab";
+import { AccountTab } from "./tabs/AccountTab";
 import { AudioTab } from "./tabs/AudioTab";
 import { GeneralTab } from "./tabs/GeneralTab";
 import { NotificationsTab } from "./tabs/NotificationsTab";
@@ -30,56 +30,55 @@ import { VideoTab } from "./tabs/VideoTab";
 
 /**
  * Layout constants (single source of truth)
- * - Avoid rem/px mismatches by deriving breakpoint from modal width.
+ * - Replaces “fixme” magic numbers with named constants.
+ * - Keeps existing behavior while making values easy to audit/change.
  */
-const SETTINGS_DIALOG_WIDTH_REM = 50;
-const SETTINGS_DIALOG_MAX_HEIGHT_REM = 40.625;
-const SETTINGS_DIALOG_MARGIN_Y_REM = -1;
-const SETTINGS_DIALOG_VIEWPORT_HEIGHT_OFFSET_REM = 2;
+const DIALOG_WIDTH_REM = 50;
+const DIALOG_MAX_HEIGHT_REM = 40.625;
+const DIALOG_MARGIN_Y_REM = -1;
+const VIEWPORT_OFFSET_REM = 2;
 
-const WIDE_SCREEN_MIN_WIDTH_REM = SETTINGS_DIALOG_WIDTH_REM; // keep breakpoint consistent
-const WIDE_SCREEN_MEDIA_QUERY = `(min-width: ${WIDE_SCREEN_MIN_WIDTH_REM}rem)`;
+const WIDE_BREAKPOINT_REM = DIALOG_WIDTH_REM;
+const WIDE_MEDIA_QUERY = `(min-width: ${WIDE_BREAKPOINT_REM}rem)`;
 
-// spacing tokens
-const TABLIST_PADDING_Y = "1rem";
-const TABLIST_PADDING_RIGHT = "1.5rem";
-const TABLIST_WIDE_PADDING_LEFT = "1rem";
-const TABLIST_NARROW_PADDING_LEFT = "0.5rem";
-const TAB_PANEL_MARGIN_TOP = "3.5rem";
+const TABLIST_PADDING_Y_REM = 1;
+const TABLIST_PADDING_RIGHT_REM = 1.5;
+const TABLIST_PADDING_LEFT_WIDE_REM = 1;
+const TABLIST_PADDING_LEFT_NARROW_REM = 0.5;
 
-const tabsStyle = css({
-  maxHeight: `${SETTINGS_DIALOG_MAX_HEIGHT_REM}rem`,
-  width: `${SETTINGS_DIALOG_WIDTH_REM}rem`,
+const TAB_PANEL_MARGIN_TOP_REM = 3.5;
+
+const dialogStyle = css({
+  maxHeight: `${DIALOG_MAX_HEIGHT_REM}rem`,
+  width: `${DIALOG_WIDTH_REM}rem`,
   maxWidth: "100%",
   overflow: "hidden",
-  marginY: `${SETTINGS_DIALOG_MARGIN_Y_REM}rem`,
-  height: `calc(100vh - ${SETTINGS_DIALOG_VIEWPORT_HEIGHT_OFFSET_REM}rem)`,
+  marginY: `${DIALOG_MARGIN_Y_REM}rem`,
+  height: `calc(100vh - ${VIEWPORT_OFFSET_REM}rem)`,
 });
 
-const tabListContainerStyle = css({
+const tabListBaseStyle = css({
   display: "flex",
   flexDirection: "column",
-  paddingY: TABLIST_PADDING_Y,
-  paddingRight: TABLIST_PADDING_RIGHT,
-
-  // Use theme-aware colors instead of hardcoded "lightGray"
+  paddingY: `${TABLIST_PADDING_Y_REM}rem`,
+  paddingRight: `${TABLIST_PADDING_RIGHT_REM}rem`,
   borderRightWidth: "1px",
   borderRightStyle: "solid",
   borderRightColor: { base: "gray.200", _dark: "gray.700" },
 });
 
-const tabListContainerWideStyle = css({
-  paddingLeft: TABLIST_WIDE_PADDING_LEFT,
+const tabListWideStyle = css({
+  paddingLeft: `${TABLIST_PADDING_LEFT_WIDE_REM}rem`,
 });
 
-const tabListContainerNarrowStyle = css({
-  paddingLeft: TABLIST_NARROW_PADDING_LEFT,
+const tabListNarrowStyle = css({
+  paddingLeft: `${TABLIST_PADDING_LEFT_NARROW_REM}rem`,
 });
 
 const tabPanelContainerStyle = css({
   display: "flex",
-  flexGrow: "1",
-  marginTop: TAB_PANEL_MARGIN_TOP,
+  flexGrow: 1,
+  marginTop: `${TAB_PANEL_MARGIN_TOP_REM}rem`,
   minWidth: 0,
 });
 
@@ -89,86 +88,81 @@ export type SettingsDialogExtended = Pick<DialogProps, "isOpen" | "onOpenChange"
 
 export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
   const { t } = useTranslation("settings");
-  const dialogEl = useRef(null);
+  const dialogEl = useRef<null>(null);
 
-  // Wide screen => labels visible. Narrow => icon-only tab list.
-  const isWideScreen = useMediaQuery(WIDE_SCREEN_MEDIA_QUERY);
-
+  const isWideScreen = useMediaQuery(WIDE_MEDIA_QUERY);
   const isAdminOrOwner = useIsAdminOrOwner();
 
-  const tabListStyle = `${tabListContainerStyle} ${isWideScreen ? tabListContainerWideStyle : tabListContainerNarrowStyle
+  const tabListStyle = `${tabListBaseStyle} ${isWideScreen ? tabListWideStyle : tabListNarrowStyle
     }`;
 
-  const tabLabel = (key: SettingsDialogExtendedKey) =>
+  const maybeLabel = (key: SettingsDialogExtendedKey) =>
     isWideScreen ? t(`tabs.${key}`) : null;
 
   return (
     <Dialog
       {...props}
-      ref={dialogEl}
+      innerRef={dialogEl}
       aria-label={t("dialog.heading")}
-      className={tabsStyle}
+      className={dialogStyle}
     >
       <Tabs defaultSelectedKey={props.defaultSelectedTab}>
-        <Heading
-          slot="title"
-          className={text({ size: "lg", weight: "bold" })}
-        >
+        <Heading slot="title" className={text({ variant: "h3", weight: "bold" })}>
           {isWideScreen && t("dialog.heading")}
         </Heading>
 
         <div className={css({ display: "flex", height: "100%" })}>
           <div className={tabListStyle}>
             <TabList border={false}>
-              <Tab isIconOnly value={SettingsDialogExtendedKey.ACCOUNT}>
-                <Icon>
+              <Tab icon value={SettingsDialogExtendedKey.ACCOUNT}>
+                <Icon name="account">
                   <RiAccountCircleLine />
                 </Icon>
-                {tabLabel(SettingsDialogExtendedKey.ACCOUNT)}
+                {maybeLabel(SettingsDialogExtendedKey.ACCOUNT)}
               </Tab>
 
-              <Tab isIconOnly value={SettingsDialogExtendedKey.AUDIO}>
-                <Icon>
+              <Tab icon value={SettingsDialogExtendedKey.AUDIO}>
+                <Icon name="audio">
                   <RiSpeakerLine />
                 </Icon>
-                {tabLabel(SettingsDialogExtendedKey.AUDIO)}
+                {maybeLabel(SettingsDialogExtendedKey.AUDIO)}
               </Tab>
 
-              <Tab isIconOnly value={SettingsDialogExtendedKey.VIDEO}>
-                <Icon>
+              <Tab icon value={SettingsDialogExtendedKey.VIDEO}>
+                <Icon name="video">
                   <RiVideoOnLine />
                 </Icon>
-                {tabLabel(SettingsDialogExtendedKey.VIDEO)}
+                {maybeLabel(SettingsDialogExtendedKey.VIDEO)}
               </Tab>
 
-              <Tab isIconOnly value={SettingsDialogExtendedKey.GENERAL}>
-                <Icon>
+              <Tab icon value={SettingsDialogExtendedKey.GENERAL}>
+                <Icon name="general">
                   <RiSettings3Line />
                 </Icon>
-                {tabLabel(SettingsDialogExtendedKey.GENERAL)}
+                {maybeLabel(SettingsDialogExtendedKey.GENERAL)}
               </Tab>
 
-              <Tab isIconOnly value={SettingsDialogExtendedKey.NOTIFICATIONS}>
-                <Icon>
+              <Tab icon value={SettingsDialogExtendedKey.NOTIFICATIONS}>
+                <Icon name="notifications">
                   <RiNotification3Line />
                 </Icon>
-                {tabLabel(SettingsDialogExtendedKey.NOTIFICATIONS)}
+                {maybeLabel(SettingsDialogExtendedKey.NOTIFICATIONS)}
               </Tab>
 
               {isAdminOrOwner && (
-                <Tab isIconOnly value={SettingsDialogExtendedKey.TRANSCRIPTION}>
-                  <Icon>
+                <Tab icon value={SettingsDialogExtendedKey.TRANSCRIPTION}>
+                  <Icon name="transcription">
                     <RiSettings3Line />
                   </Icon>
-                  {tabLabel(SettingsDialogExtendedKey.TRANSCRIPTION)}
+                  {maybeLabel(SettingsDialogExtendedKey.TRANSCRIPTION)}
                 </Tab>
               )}
 
-              <Tab isIconOnly value={SettingsDialogExtendedKey.ACCESSIBILITY}>
-                <Icon>
+              <Tab icon value={SettingsDialogExtendedKey.ACCESSIBILITY}>
+                <Icon name="accessibility">
                   <RiEyeLine />
                 </Icon>
-                {tabLabel(SettingsDialogExtendedKey.ACCESSIBILITY)}
+                {maybeLabel(SettingsDialogExtendedKey.ACCESSIBILITY)}
               </Tab>
             </TabList>
           </div>
@@ -179,7 +173,6 @@ export const SettingsDialogExtended = (props: SettingsDialogExtended) => {
             <VideoTab />
             <GeneralTab />
             <NotificationsTab />
-            {/* Transcription tab won't be accessible if the tab is not active in the tab list */}
             {isAdminOrOwner && <TranscriptionTab />}
             <AccessibilityTab />
           </div>


### PR DESCRIPTION
## Closes
Closes #30

## Summary
Refactors SettingsDialogExtended styles to remove hardcoded “fixme” layout values.
Introduces named layout constants and token-driven styles, consolidating the
responsive breakpoint so sizing logic stays consistent and maintainable.

## Changes
- Replaced magic numbers (50rem, 40.625rem, -1rem, 800px, etc.) with named constants.
- Unified wide-screen breakpoint to match modal width (`min-width: 50rem`).
- Removed ad-hoc inline responsive styling by using css() style variants.
- Replaced hardcoded border color with theme-aware token values.

## Verification
- Manual: opened settings dialog in narrow + wide viewport; tabs remain usable and not clipped.
- Manual: checked light/dark theme for border visibility.
- `cd src/frontend && npm run lint && npm run check && npm run build`

## Evidence
- No remaining `// fixme` markers in SettingsDialogExtended styles.
- Breakpoint is derived from the same constant used for modal width.