### PR TITLE
630:P3 Facade hooks to decompose useRoomContext global coupling (#55)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- ✨(rooms) facade hooks to narrow useRoomContext coupling (issue #55)
 - ✨(frontend) extract PanelToggleButton to eliminate duplicated
   panel toggle structure (issue #54)
 - ✨(frontend) replace custom debounce with useDebounceValue from usehooks-ts

--- a/src/frontend/src/features/notifications/hooks/useNotifyParticipants.ts
+++ b/src/frontend/src/features/notifications/hooks/useNotifyParticipants.ts
@@ -1,9 +1,9 @@
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from '@/features/rooms/livekit/hooks/useLocalParticipant'
 import { NotificationType } from '../NotificationType'
 import { NotificationPayload } from '../NotificationPayload'
 
 export const useNotifyParticipants = () => {
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const notifyParticipants = async <T extends Record<string, any>>(options: {
@@ -27,7 +27,7 @@ export const useNotifyParticipants = () => {
     const encoder = new TextEncoder()
     const data = encoder.encode(JSON.stringify(payload))
 
-    await room.localParticipant.publishData(data, {
+    await localParticipant.publishData(data, {
       reliable,
       destinationIdentities,
     })

--- a/src/frontend/src/features/recording/components/ControlsButton.tsx
+++ b/src/frontend/src/features/recording/components/ControlsButton.tsx
@@ -5,7 +5,7 @@ import { Button, Icon, Text } from '@/primitives'
 import { useTranslation } from 'react-i18next'
 import { RecordingStatuses } from '../hooks/useRecordingStatuses'
 import { ReactNode, useEffect, useRef, useState } from 'react'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomConnectionState } from '@/features/rooms/livekit/hooks/useRoomConnectionState'
 import { ConnectionState } from 'livekit-client'
 import { Button as RACButton } from 'react-aria-components'
 import { parseLineBreaks } from '@/utils/parseLineBreaks'
@@ -53,8 +53,8 @@ export const ControlsButton = ({
     })
   }, [])
 
-  const room = useRoomContext()
-  const isRoomConnected = room.state == ConnectionState.Connected
+  const roomState = useRoomConnectionState()
+  const isRoomConnected = roomState == ConnectionState.Connected
 
   const [showSaving, setShowSaving] = useState(false)
   const timeoutRef = useRef<NodeJS.Timeout>()

--- a/src/frontend/src/features/recording/components/LimitReachedAlertDialog.tsx
+++ b/src/frontend/src/features/recording/components/LimitReachedAlertDialog.tsx
@@ -7,7 +7,7 @@ import { NotificationType } from '@/features/notifications'
 import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
 import { RoomEvent } from 'livekit-client'
 import { decodeNotificationDataReceived } from '@/features/notifications/utils'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomEventEmitter } from '@/features/rooms/livekit/hooks/useRoomEventEmitter'
 
 export const LimitReachedAlertDialog = () => {
   const [isAlertOpen, setIsAlertOpen] = useState(false)
@@ -16,7 +16,7 @@ export const LimitReachedAlertDialog = () => {
     keyPrefix: 'recordingStateToast.limitReachedAlert',
   })
 
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
   const isAdminOrOwner = useIsAdminOrOwner()
   const maxDuration = useHumanizeRecordingMaxDuration()
 

--- a/src/frontend/src/features/rooms/livekit/components/controls/HandToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/HandToggle.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { RiHand } from '@remixicon/react'
 import { ToggleButton } from '@/primitives'
 import { css } from '@/styled-system/css'
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from '../../hooks/useLocalParticipant'
 import { useRaisedHand } from '@/features/rooms/livekit/hooks/useRaisedHand'
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -15,12 +15,12 @@ const SPEAKING_DETECTION_DELAY = 3000
 export const HandToggle = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.hand' })
 
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
   const { isHandRaised, toggleRaisedHand } = useRaisedHand({
-    participant: room.localParticipant,
+    participant: localParticipant,
   })
 
-  const isSpeaking = room.localParticipant.isSpeaking
+  const isSpeaking = localParticipant.isSpeaking
   const speakingTimerRef = useRef<NodeJS.Timeout | null>(null)
   const [hasShownToast, setHasShownToast] = useState(false)
 
@@ -43,7 +43,7 @@ export const HandToggle = () => {
           if (isHandRaised) toggleRaisedHand()
           resetToastState()
         }
-        showLowerHandToast(room.localParticipant, onClose)
+        showLowerHandToast(localParticipant, onClose)
       }, SPEAKING_DETECTION_DELAY)
     }
     if ((!isSpeaking || !isHandRaised) && speakingTimerRef.current) {

--- a/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { RiEmotionLine } from '@remixicon/react'
 import { useState, useRef, useEffect } from 'react'
 import { css } from '@/styled-system/css'
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from '../../hooks/useLocalParticipant'
 import { ToggleButton, Button } from '@/primitives'
 import { NotificationType } from '@/features/notifications/NotificationType'
 import { NotificationPayload } from '@/features/notifications/NotificationPayload'
@@ -37,7 +37,7 @@ export const ReactionsToggle = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.reactions' })
   const [reactions, setReactions] = useState<Reaction[]>([])
   const instanceIdRef = useRef(0)
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
 
   const [isVisible, setIsVisible] = useState(false)
 
@@ -50,12 +50,12 @@ export const ReactionsToggle = () => {
       },
     }
     const data = encoder.encode(JSON.stringify(payload))
-    await room.localParticipant.publishData(data, { reliable: true })
+    await localParticipant.publishData(data, { reliable: true })
 
     const newReaction = {
       id: instanceIdRef.current++,
       emoji,
-      participant: room.localParticipant,
+      participant: localParticipant,
     }
     setReactions((prev) => [...prev, newReaction])
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useConnectionObserver.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useConnectionObserver.ts
@@ -1,7 +1,5 @@
-import {
-  useRemoteParticipants,
-  useRoomContext,
-} from '@livekit/components-react'
+import { useRemoteParticipants } from '@livekit/components-react'
+import { useRoomEventEmitter } from './useRoomEventEmitter'
 import { useEffect, useRef } from 'react'
 import { DisconnectReason, RoomEvent } from 'livekit-client'
 import { useIsAnalyticsEnabled } from '@/features/analytics/hooks/useIsAnalyticsEnabled'
@@ -12,7 +10,7 @@ import { userPreferencesStore } from '@/stores/userPreferences'
 import { useSnapshot } from 'valtio'
 
 export const useConnectionObserver = () => {
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
   const connectionStartTimeRef = useRef<number | null>(null)
 
   const { data } = useConfig()

--- a/src/frontend/src/features/rooms/livekit/hooks/useLocalParticipant.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useLocalParticipant.ts
@@ -1,0 +1,7 @@
+import { useRoomContext } from '@livekit/components-react'
+
+/** Facade hook: exposes only the local participant from the LiveKit room. */
+export const useLocalParticipant = () => {
+  const room = useRoomContext()
+  return room.localParticipant
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useNoiseReduction.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useNoiseReduction.ts
@@ -1,19 +1,19 @@
 import { useEffect } from 'react'
 import { Track } from 'livekit-client'
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from './useLocalParticipant'
 import { RnnNoiseProcessor } from '../processors/RnnNoiseProcessor'
 import { usePersistentUserChoices } from './usePersistentUserChoices'
 import { useNoiseReductionAvailable } from '@/features/rooms/livekit/hooks/useNoiseReductionAvailable'
 
 export const useNoiseReduction = () => {
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
   const noiseReductionAvailable = useNoiseReductionAvailable()
 
   const {
     userChoices: { noiseReductionEnabled },
   } = usePersistentUserChoices()
 
-  const audioTrack = room.localParticipant.getTrackPublication(
+  const audioTrack = localParticipant.getTrackPublication(
     Track.Source.Microphone
   )?.audioTrack
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionActions.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionActions.ts
@@ -1,0 +1,12 @@
+import { useRoomContext } from '@livekit/components-react'
+
+/** Facade hook: exposes room-level actions without leaking the full Room object. */
+export const useRoomConnectionActions = () => {
+  const room = useRoomContext()
+  return {
+    disconnect: (stopTracks?: boolean) => room.disconnect(stopTracks),
+    setLocalParticipantName: (name: string) =>
+      room.localParticipant.setName(name),
+    localParticipantName: room.localParticipant.name,
+  }
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionState.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionState.ts
@@ -1,0 +1,8 @@
+import { useRoomContext } from '@livekit/components-react'
+import type { ConnectionState } from 'livekit-client'
+
+/** Facade hook: exposes only the room's current connection state. */
+export const useRoomConnectionState = (): ConnectionState => {
+  const room = useRoomContext()
+  return room.state
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoomEventEmitter.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoomEventEmitter.ts
@@ -1,0 +1,8 @@
+import { useRoomContext } from '@livekit/components-react'
+import type { Room } from 'livekit-client'
+
+/** Facade hook: exposes the LiveKit Room narrowed to its event-emitter API. */
+export const useRoomEventEmitter = (): Pick<Room, 'on' | 'off' | 'emit'> => {
+  const room = useRoomContext()
+  return room
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useVideoResolutionSubscription.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useVideoResolutionSubscription.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { usePersistentUserChoices } from './usePersistentUserChoices'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomEventEmitter } from './useRoomEventEmitter'
 import {
   RemoteParticipant,
   RemoteTrackPublication,
@@ -18,7 +18,7 @@ export const useVideoResolutionSubscription = () => {
     userChoices: { videoSubscribeQuality },
   } = usePersistentUserChoices()
 
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
 
   useEffect(() => {
     if (!room) return

--- a/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
@@ -1,6 +1,6 @@
 import { A, Badge, Button, DialogProps, Field, H, P } from '@/primitives'
 import { Trans, useTranslation } from 'react-i18next'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomConnectionActions } from '@/features/rooms/livekit/hooks/useRoomConnectionActions'
 import { useUser } from '@/features/auth'
 import { css } from '@/styled-system/css'
 import { TabPanel, TabPanelProps } from '@/primitives/Tabs'
@@ -15,16 +15,17 @@ export type AccountTabProps = Pick<DialogProps, 'onOpenChange'> &
 export const AccountTab = ({ id, onOpenChange }: AccountTabProps) => {
   const { t } = useTranslation('settings')
   const { saveUsername } = usePersistentUserChoices()
-  const room = useRoomContext()
+  const { setLocalParticipantName, localParticipantName } =
+    useRoomConnectionActions()
   const { user, isLoggedIn, logout } = useUser()
-  const [name, setName] = useState(room?.localParticipant.name ?? '')
+  const [name, setName] = useState(localParticipantName ?? '')
   const userDisplay =
     user?.full_name && user?.email
       ? `${user.full_name} (${user.email})`
       : user?.email
 
   const handleOnSubmit = () => {
-    if (room) room.localParticipant.setName(name)
+    setLocalParticipantName(name)
     saveUsername(name)
     if (onOpenChange) onOpenChange(false)
   }

--- a/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
+++ b/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
@@ -2,14 +2,14 @@ import { useSnapshot } from 'valtio'
 import { layoutStore } from '@/stores/layout'
 import { useStartSubtitle } from '../api/startSubtitle'
 import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomEventEmitter } from '@/features/rooms/livekit/hooks/useRoomEventEmitter'
 import { useEffect } from 'react'
 import { RoomEvent } from 'livekit-client'
 
 export const useSubtitles = () => {
   const layoutSnap = useSnapshot(layoutStore)
 
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
   const apiRoomData = useRoomData()
   const { mutateAsync: startSubtitleRoom, isPending } = useStartSubtitle()
 


### PR DESCRIPTION
Closes #55
Problem
useRoomContext() from @livekit/components-react was called raw in 10+ components, each receiving the entire Room object even when only one concern was needed (e.g. just the local participant, just event subscription, just connection state). This created unnecessary coupling across unrelated subsystems.
Approach — Facade pattern (Structural)
Added 4 focused facade hooks that narrow the Room API to exactly what each consumer needs:

useLocalParticipant — for components that only need room.localParticipant
useRoomEventEmitter — for components that only call room.on / room.off
useRoomConnectionState — for components that only check room.state
useRoomConnectionActions — for components that call room.disconnect() or room.localParticipant.setName()

Migrated 10 consumer files to use the appropriate facade.
Evidence

Adding a new room state domain no longer requires touching unrelated components
ChatPanel-equivalent components no longer import the full Room object for event subscription alone
Each hook's type signature documents exactly what the component depends on

Verification

48 pre-existing type errors exist in the repo due to missing package declarations (@livekit/components-core, @mediapipe/tasks-vision, etc.) — these are unrelated to this refactor and reproducible on main before any changes
All modified files compile cleanly in isolation
Manual: join a room and verify all UI features work (recording controls, reactions, hand raise, noise reduction, subtitles, account name change)