### PR TITLE
630:P3 StorageRepository to unify localStorage access (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+- ✨(rooms) facade hooks to narrow useRoomContext coupling (issue #55)
 - ✨(frontend) extract PanelToggleButton to eliminate duplicated
   panel toggle structure (issue #54)
 - ✨(frontend) replace custom debounce with useDebounceValue from usehooks-ts

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+- ✨(stores) StorageRepository to unify localStorage access (issue #58)
+
 - ✨(rooms) facade hooks to narrow useRoomContext coupling (issue #55)
 - ✨(frontend) extract PanelToggleButton to eliminate duplicated
   panel toggle structure (issue #54)

--- a/src/frontend/src/features/auth/utils/silentLogin.ts
+++ b/src/frontend/src/features/auth/utils/silentLogin.ts
@@ -1,9 +1,12 @@
 import { authUrl } from '@/features/auth'
-
-const SILENT_LOGIN_RETRY_KEY = 'silent-login-retry'
+import { STORAGE_KEYS } from '@/utils/storageKeys'
+import { storageRepository } from '@/utils/StorageRepository'
 
 const isRetryAllowed = () => {
-  const lastRetryDate = localStorage.getItem(SILENT_LOGIN_RETRY_KEY)
+  const lastRetryDate = storageRepository.load<string | null>(
+    STORAGE_KEYS.SILENT_LOGIN_RETRY,
+    null
+  )
   if (!lastRetryDate) {
     return true
   }
@@ -14,7 +17,7 @@ const isRetryAllowed = () => {
 const setNextRetryTime = (retryIntervalInSeconds: number) => {
   const now = new Date()
   const nextRetryTime = now.getTime() + retryIntervalInSeconds * 1000
-  localStorage.setItem(SILENT_LOGIN_RETRY_KEY, String(nextRetryTime))
+  storageRepository.save(STORAGE_KEYS.SILENT_LOGIN_RETRY, String(nextRetryTime))
 }
 
 const initiateSilentLogin = () => {

--- a/src/frontend/src/features/notifications/hooks/useNotifyParticipants.ts
+++ b/src/frontend/src/features/notifications/hooks/useNotifyParticipants.ts
@@ -1,9 +1,9 @@
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from '@/features/rooms/livekit/hooks/useLocalParticipant'
 import { NotificationType } from '../NotificationType'
 import { NotificationPayload } from '../NotificationPayload'
 
 export const useNotifyParticipants = () => {
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const notifyParticipants = async <T extends Record<string, any>>(options: {
@@ -27,7 +27,7 @@ export const useNotifyParticipants = () => {
     const encoder = new TextEncoder()
     const data = encoder.encode(JSON.stringify(payload))
 
-    await room.localParticipant.publishData(data, {
+    await localParticipant.publishData(data, {
       reliable,
       destinationIdentities,
     })

--- a/src/frontend/src/features/recording/components/ControlsButton.tsx
+++ b/src/frontend/src/features/recording/components/ControlsButton.tsx
@@ -5,7 +5,7 @@ import { Button, Icon, Text } from '@/primitives'
 import { useTranslation } from 'react-i18next'
 import { RecordingStatuses } from '../hooks/useRecordingStatuses'
 import { ReactNode, useEffect, useRef, useState } from 'react'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomConnectionState } from '@/features/rooms/livekit/hooks/useRoomConnectionState'
 import { ConnectionState } from 'livekit-client'
 import { Button as RACButton } from 'react-aria-components'
 import { parseLineBreaks } from '@/utils/parseLineBreaks'
@@ -53,8 +53,8 @@ export const ControlsButton = ({
     })
   }, [])
 
-  const room = useRoomContext()
-  const isRoomConnected = room.state == ConnectionState.Connected
+  const roomState = useRoomConnectionState()
+  const isRoomConnected = roomState == ConnectionState.Connected
 
   const [showSaving, setShowSaving] = useState(false)
   const timeoutRef = useRef<NodeJS.Timeout>()

--- a/src/frontend/src/features/recording/components/LimitReachedAlertDialog.tsx
+++ b/src/frontend/src/features/recording/components/LimitReachedAlertDialog.tsx
@@ -7,7 +7,7 @@ import { NotificationType } from '@/features/notifications'
 import { useIsAdminOrOwner } from '@/features/rooms/livekit/hooks/useIsAdminOrOwner'
 import { RoomEvent } from 'livekit-client'
 import { decodeNotificationDataReceived } from '@/features/notifications/utils'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomEventEmitter } from '@/features/rooms/livekit/hooks/useRoomEventEmitter'
 
 export const LimitReachedAlertDialog = () => {
   const [isAlertOpen, setIsAlertOpen] = useState(false)
@@ -16,7 +16,7 @@ export const LimitReachedAlertDialog = () => {
     keyPrefix: 'recordingStateToast.limitReachedAlert',
   })
 
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
   const isAdminOrOwner = useIsAdminOrOwner()
   const maxDuration = useHumanizeRecordingMaxDuration()
 

--- a/src/frontend/src/features/rooms/livekit/components/controls/HandToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/HandToggle.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { RiHand } from '@remixicon/react'
 import { ToggleButton } from '@/primitives'
 import { css } from '@/styled-system/css'
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from '../../hooks/useLocalParticipant'
 import { useRaisedHand } from '@/features/rooms/livekit/hooks/useRaisedHand'
 import { useEffect, useRef, useState } from 'react'
 import {
@@ -15,12 +15,12 @@ const SPEAKING_DETECTION_DELAY = 3000
 export const HandToggle = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.hand' })
 
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
   const { isHandRaised, toggleRaisedHand } = useRaisedHand({
-    participant: room.localParticipant,
+    participant: localParticipant,
   })
 
-  const isSpeaking = room.localParticipant.isSpeaking
+  const isSpeaking = localParticipant.isSpeaking
   const speakingTimerRef = useRef<NodeJS.Timeout | null>(null)
   const [hasShownToast, setHasShownToast] = useState(false)
 
@@ -43,7 +43,7 @@ export const HandToggle = () => {
           if (isHandRaised) toggleRaisedHand()
           resetToastState()
         }
-        showLowerHandToast(room.localParticipant, onClose)
+        showLowerHandToast(localParticipant, onClose)
       }, SPEAKING_DETECTION_DELAY)
     }
     if ((!isSpeaking || !isHandRaised) && speakingTimerRef.current) {

--- a/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
+++ b/src/frontend/src/features/rooms/livekit/components/controls/ReactionsToggle.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { RiEmotionLine } from '@remixicon/react'
 import { useState, useRef, useEffect } from 'react'
 import { css } from '@/styled-system/css'
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from '../../hooks/useLocalParticipant'
 import { ToggleButton, Button } from '@/primitives'
 import { NotificationType } from '@/features/notifications/NotificationType'
 import { NotificationPayload } from '@/features/notifications/NotificationPayload'
@@ -37,7 +37,7 @@ export const ReactionsToggle = () => {
   const { t } = useTranslation('rooms', { keyPrefix: 'controls.reactions' })
   const [reactions, setReactions] = useState<Reaction[]>([])
   const instanceIdRef = useRef(0)
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
 
   const [isVisible, setIsVisible] = useState(false)
 
@@ -50,12 +50,12 @@ export const ReactionsToggle = () => {
       },
     }
     const data = encoder.encode(JSON.stringify(payload))
-    await room.localParticipant.publishData(data, { reliable: true })
+    await localParticipant.publishData(data, { reliable: true })
 
     const newReaction = {
       id: instanceIdRef.current++,
       emoji,
-      participant: room.localParticipant,
+      participant: localParticipant,
     }
     setReactions((prev) => [...prev, newReaction])
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useConnectionObserver.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useConnectionObserver.ts
@@ -1,7 +1,5 @@
-import {
-  useRemoteParticipants,
-  useRoomContext,
-} from '@livekit/components-react'
+import { useRemoteParticipants } from '@livekit/components-react'
+import { useRoomEventEmitter } from './useRoomEventEmitter'
 import { useEffect, useRef } from 'react'
 import { DisconnectReason, RoomEvent } from 'livekit-client'
 import { useIsAnalyticsEnabled } from '@/features/analytics/hooks/useIsAnalyticsEnabled'
@@ -12,7 +10,7 @@ import { userPreferencesStore } from '@/stores/userPreferences'
 import { useSnapshot } from 'valtio'
 
 export const useConnectionObserver = () => {
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
   const connectionStartTimeRef = useRef<number | null>(null)
 
   const { data } = useConfig()

--- a/src/frontend/src/features/rooms/livekit/hooks/useLocalParticipant.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useLocalParticipant.ts
@@ -1,0 +1,7 @@
+import { useRoomContext } from '@livekit/components-react'
+
+/** Facade hook: exposes only the local participant from the LiveKit room. */
+export const useLocalParticipant = () => {
+  const room = useRoomContext()
+  return room.localParticipant
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useNoiseReduction.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useNoiseReduction.ts
@@ -1,19 +1,19 @@
 import { useEffect } from 'react'
 import { Track } from 'livekit-client'
-import { useRoomContext } from '@livekit/components-react'
+import { useLocalParticipant } from './useLocalParticipant'
 import { RnnNoiseProcessor } from '../processors/RnnNoiseProcessor'
 import { usePersistentUserChoices } from './usePersistentUserChoices'
 import { useNoiseReductionAvailable } from '@/features/rooms/livekit/hooks/useNoiseReductionAvailable'
 
 export const useNoiseReduction = () => {
-  const room = useRoomContext()
+  const localParticipant = useLocalParticipant()
   const noiseReductionAvailable = useNoiseReductionAvailable()
 
   const {
     userChoices: { noiseReductionEnabled },
   } = usePersistentUserChoices()
 
-  const audioTrack = room.localParticipant.getTrackPublication(
+  const audioTrack = localParticipant.getTrackPublication(
     Track.Source.Microphone
   )?.audioTrack
 

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionActions.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionActions.ts
@@ -1,0 +1,12 @@
+import { useRoomContext } from '@livekit/components-react'
+
+/** Facade hook: exposes room-level actions without leaking the full Room object. */
+export const useRoomConnectionActions = () => {
+  const room = useRoomContext()
+  return {
+    disconnect: (stopTracks?: boolean) => room.disconnect(stopTracks),
+    setLocalParticipantName: (name: string) =>
+      room.localParticipant.setName(name),
+    localParticipantName: room.localParticipant.name,
+  }
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionState.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoomConnectionState.ts
@@ -1,0 +1,8 @@
+import { useRoomContext } from '@livekit/components-react'
+import type { ConnectionState } from 'livekit-client'
+
+/** Facade hook: exposes only the room's current connection state. */
+export const useRoomConnectionState = (): ConnectionState => {
+  const room = useRoomContext()
+  return room.state
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useRoomEventEmitter.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useRoomEventEmitter.ts
@@ -1,0 +1,8 @@
+import { useRoomContext } from '@livekit/components-react'
+import type { Room } from 'livekit-client'
+
+/** Facade hook: exposes the LiveKit Room narrowed to its event-emitter API. */
+export const useRoomEventEmitter = (): Pick<Room, 'on' | 'off' | 'emit'> => {
+  const room = useRoomContext()
+  return room
+}

--- a/src/frontend/src/features/rooms/livekit/hooks/useVideoResolutionSubscription.ts
+++ b/src/frontend/src/features/rooms/livekit/hooks/useVideoResolutionSubscription.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { usePersistentUserChoices } from './usePersistentUserChoices'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomEventEmitter } from './useRoomEventEmitter'
 import {
   RemoteParticipant,
   RemoteTrackPublication,
@@ -18,7 +18,7 @@ export const useVideoResolutionSubscription = () => {
     userChoices: { videoSubscribeQuality },
   } = usePersistentUserChoices()
 
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
 
   useEffect(() => {
     if (!room) return

--- a/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
+++ b/src/frontend/src/features/settings/components/tabs/AccountTab.tsx
@@ -1,6 +1,6 @@
 import { A, Badge, Button, DialogProps, Field, H, P } from '@/primitives'
 import { Trans, useTranslation } from 'react-i18next'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomConnectionActions } from '@/features/rooms/livekit/hooks/useRoomConnectionActions'
 import { useUser } from '@/features/auth'
 import { css } from '@/styled-system/css'
 import { TabPanel, TabPanelProps } from '@/primitives/Tabs'
@@ -15,16 +15,17 @@ export type AccountTabProps = Pick<DialogProps, 'onOpenChange'> &
 export const AccountTab = ({ id, onOpenChange }: AccountTabProps) => {
   const { t } = useTranslation('settings')
   const { saveUsername } = usePersistentUserChoices()
-  const room = useRoomContext()
+  const { setLocalParticipantName, localParticipantName } =
+    useRoomConnectionActions()
   const { user, isLoggedIn, logout } = useUser()
-  const [name, setName] = useState(room?.localParticipant.name ?? '')
+  const [name, setName] = useState(localParticipantName ?? '')
   const userDisplay =
     user?.full_name && user?.email
       ? `${user.full_name} (${user.email})`
       : user?.email
 
   const handleOnSubmit = () => {
-    if (room) room.localParticipant.setName(name)
+    setLocalParticipantName(name)
     saveUsername(name)
     if (onOpenChange) onOpenChange(false)
   }

--- a/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
+++ b/src/frontend/src/features/subtitle/hooks/useSubtitles.tsx
@@ -2,14 +2,14 @@ import { useSnapshot } from 'valtio'
 import { layoutStore } from '@/stores/layout'
 import { useStartSubtitle } from '../api/startSubtitle'
 import { useRoomData } from '@/features/rooms/livekit/hooks/useRoomData'
-import { useRoomContext } from '@livekit/components-react'
+import { useRoomEventEmitter } from '@/features/rooms/livekit/hooks/useRoomEventEmitter'
 import { useEffect } from 'react'
 import { RoomEvent } from 'livekit-client'
 
 export const useSubtitles = () => {
   const layoutSnap = useSnapshot(layoutStore)
 
-  const room = useRoomContext()
+  const room = useRoomEventEmitter()
   const apiRoomData = useRoomData()
   const { mutateAsync: startSubtitleRoom, isPending } = useStartSubtitle()
 

--- a/src/frontend/src/stores/accessibility.ts
+++ b/src/frontend/src/stores/accessibility.ts
@@ -1,6 +1,7 @@
 import { proxy, subscribe } from 'valtio'
 import { STORAGE_KEYS } from '@/utils/storageKeys'
 import { deserializeToProxyMap } from '@/utils/valtio'
+import { storageRepository } from '@/utils/StorageRepository'
 
 type AccessibilityState = {
   announceReactions: boolean
@@ -11,57 +12,38 @@ const DEFAULT_STATE: AccessibilityState = {
 }
 
 function getAccessibilityState(): AccessibilityState {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEYS.ACCESSIBILITY)
-    if (stored) {
-      const parsed = JSON.parse(stored)
-      return {
-        ...DEFAULT_STATE,
-        ...parsed,
-        announceReactions:
-          typeof parsed.announceReactions === 'boolean'
-            ? parsed.announceReactions
-            : DEFAULT_STATE.announceReactions,
-      }
+  const stored = storageRepository.load<AccessibilityState | null>(
+    STORAGE_KEYS.ACCESSIBILITY,
+    null
+  )
+  if (stored) {
+    return {
+      ...DEFAULT_STATE,
+      ...stored,
+      announceReactions:
+        typeof stored.announceReactions === 'boolean'
+          ? stored.announceReactions
+          : DEFAULT_STATE.announceReactions,
     }
-
-    // Legacy migration: if the setting was previously stored in notifications
-    const legacy = localStorage.getItem(STORAGE_KEYS.NOTIFICATIONS)
-    if (legacy) {
-      try {
-        const parsedLegacy = JSON.parse(legacy, deserializeToProxyMap)
-        if (typeof parsedLegacy?.announceReactions === 'boolean') {
-          const migratedState: AccessibilityState = {
-            ...DEFAULT_STATE,
-            ...parsedLegacy,
-            announceReactions: parsedLegacy.announceReactions,
-          }
-
-          try {
-            localStorage.setItem(
-              STORAGE_KEYS.ACCESSIBILITY,
-              JSON.stringify(migratedState)
-            )
-            localStorage.removeItem(STORAGE_KEYS.NOTIFICATIONS)
-          } catch {
-            // ignore persistence issues during migration
-          }
-
-          return migratedState
-        }
-      } catch {
-        // ignore legacy parsing issues
-      }
-    }
-
-    return DEFAULT_STATE
-  } catch (error: unknown) {
-    console.error(
-      '[AccessibilityStore] Failed to parse stored settings:',
-      error
-    )
-    return DEFAULT_STATE
   }
+
+  // Legacy migration: if the setting was previously stored in notifications
+  const legacy = storageRepository.load<Record<string, unknown> | null>(
+    STORAGE_KEYS.NOTIFICATIONS,
+    null,
+    deserializeToProxyMap
+  )
+  if (legacy && typeof legacy?.announceReactions === 'boolean') {
+    const migratedState: AccessibilityState = {
+      ...DEFAULT_STATE,
+      announceReactions: legacy.announceReactions as boolean,
+    }
+    storageRepository.save(STORAGE_KEYS.ACCESSIBILITY, migratedState)
+    storageRepository.remove(STORAGE_KEYS.NOTIFICATIONS)
+    return migratedState
+  }
+
+  return DEFAULT_STATE
 }
 
 export const accessibilityStore = proxy<AccessibilityState>(
@@ -69,8 +51,5 @@ export const accessibilityStore = proxy<AccessibilityState>(
 )
 
 subscribe(accessibilityStore, () => {
-  localStorage.setItem(
-    STORAGE_KEYS.ACCESSIBILITY,
-    JSON.stringify(accessibilityStore)
-  )
+  storageRepository.save(STORAGE_KEYS.ACCESSIBILITY, accessibilityStore)
 })

--- a/src/frontend/src/stores/notifications.ts
+++ b/src/frontend/src/stores/notifications.ts
@@ -2,6 +2,7 @@ import { proxy, subscribe } from 'valtio'
 import { proxyMap } from 'valtio/utils'
 import { deserializeToProxyMap, serializeProxyMap } from '@/utils/valtio'
 import { STORAGE_KEYS } from '@/utils/storageKeys'
+import { storageRepository } from '@/utils/StorageRepository'
 import { NotificationType } from '@/features/notifications/NotificationType'
 
 type State = {
@@ -21,39 +22,37 @@ const DEFAULT_STATE: State = {
 }
 
 function getNotificationsState(): State {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEYS.NOTIFICATIONS)
-    if (!stored) return DEFAULT_STATE
-    const parsed = JSON.parse(stored, deserializeToProxyMap)
-    // Ensure all default notification types exist in the recovered state
-    return {
-      ...DEFAULT_STATE,
-      ...parsed,
-      soundNotifications: proxyMap(
-        new Map(
-          Array.from(DEFAULT_STATE.soundNotifications.keys()).map((key) => [
-            key,
-            parsed.soundNotifications.has(key)
-              ? parsed.soundNotifications.get(key)
-              : DEFAULT_STATE.soundNotifications.get(key),
-          ])
-        )
-      ),
-    }
-  } catch (error: unknown) {
-    console.error(
-      '[NotificationsStore] Failed to parse stored settings:',
-      error
-    )
-    return DEFAULT_STATE
+  const parsed = storageRepository.load<State | null>(
+    STORAGE_KEYS.NOTIFICATIONS,
+    null,
+    deserializeToProxyMap
+  )
+  if (!parsed) return DEFAULT_STATE
+  // Ensure all default notification types exist in the recovered state
+  return {
+    ...DEFAULT_STATE,
+    ...parsed,
+    soundNotifications: proxyMap(
+      new Map(
+        Array.from(DEFAULT_STATE.soundNotifications.keys()).map((key) => [
+          key,
+          parsed.soundNotifications instanceof Map &&
+          parsed.soundNotifications.has(key)
+            ? (parsed.soundNotifications.get(key) ??
+              DEFAULT_STATE.soundNotifications.get(key)!)
+            : DEFAULT_STATE.soundNotifications.get(key)!,
+        ])
+      )
+    ),
   }
 }
 
 export const notificationsStore = proxy<State>(getNotificationsState())
 
 subscribe(notificationsStore, () => {
-  localStorage.setItem(
+  storageRepository.save(
     STORAGE_KEYS.NOTIFICATIONS,
-    JSON.stringify(notificationsStore, serializeProxyMap)
+    notificationsStore,
+    serializeProxyMap
   )
 })

--- a/src/frontend/src/stores/userPreferences.ts
+++ b/src/frontend/src/stores/userPreferences.ts
@@ -1,6 +1,7 @@
 import { proxy } from 'valtio'
 import { subscribe } from 'valtio/index'
 import { STORAGE_KEYS } from '@/utils/storageKeys'
+import { storageRepository } from '@/utils/StorageRepository'
 
 type State = {
   is_idle_disconnect_modal_enabled: boolean
@@ -11,28 +12,14 @@ const DEFAULT_STATE = {
 }
 
 function getUserPreferencesState(): State {
-  try {
-    const stored = localStorage.getItem(STORAGE_KEYS.USER_PREFERENCES)
-    if (!stored) return DEFAULT_STATE
-    const parsed = JSON.parse(stored)
-    return {
-      ...DEFAULT_STATE,
-      ...parsed,
-    }
-  } catch (error: unknown) {
-    console.error(
-      '[UserPreferencesStore] Failed to parse stored settings:',
-      error
-    )
-    return DEFAULT_STATE
-  }
+  return storageRepository.load<State>(
+    STORAGE_KEYS.USER_PREFERENCES,
+    DEFAULT_STATE
+  )
 }
 
 export const userPreferencesStore = proxy<State>(getUserPreferencesState())
 
 subscribe(userPreferencesStore, () => {
-  localStorage.setItem(
-    STORAGE_KEYS.USER_PREFERENCES,
-    JSON.stringify(userPreferencesStore)
-  )
+  storageRepository.save(STORAGE_KEYS.USER_PREFERENCES, userPreferencesStore)
 })

--- a/src/frontend/src/utils/StorageRepository.ts
+++ b/src/frontend/src/utils/StorageRepository.ts
@@ -1,0 +1,69 @@
+/**
+ * StorageRepository: a testable abstraction over localStorage.
+ *
+ * Before this abstraction, each store (userPreferences, notifications,
+ * accessibility) and silentLogin contained identical try/catch localStorage
+ * boilerplate with raw string keys scattered across files. This created:
+ *   - Duplicated error handling in every store
+ *   - No way to swap the storage backend without editing every consumer
+ *   - Impossible to unit test without mocking localStorage per-file
+ *
+ * The LocalStorageRepository centralises all of that. Swapping to
+ * sessionStorage or a server API now requires changing one class only.
+ *
+ * Pattern: Repository (Structural) — wraps a storage mechanism behind
+ * a stable interface so consumers depend on the abstraction, not the
+ * implementation.
+ */
+export interface IStorageRepository {
+  load<T>(
+    key: string,
+    defaultValue: T,
+    reviver?: (key: string, value: unknown) => unknown
+  ): T
+  save<T>(
+    key: string,
+    value: T,
+    replacer?: (key: string, value: unknown) => unknown
+  ): void
+  remove(key: string): void
+}
+
+export class LocalStorageRepository implements IStorageRepository {
+  load<T>(
+    key: string,
+    defaultValue: T,
+    reviver?: (key: string, value: unknown) => unknown
+  ): T {
+    try {
+      const stored = localStorage.getItem(key)
+      if (!stored) return defaultValue
+      return JSON.parse(stored, reviver) as T
+    } catch (error) {
+      console.error(`[StorageRepository] Failed to load key "${key}":`, error)
+      return defaultValue
+    }
+  }
+
+  save<T>(
+    key: string,
+    value: T,
+    replacer?: (key: string, value: unknown) => unknown
+  ): void {
+    try {
+      localStorage.setItem(key, JSON.stringify(value, replacer))
+    } catch (error) {
+      console.error(`[StorageRepository] Failed to save key "${key}":`, error)
+    }
+  }
+
+  remove(key: string): void {
+    try {
+      localStorage.removeItem(key)
+    } catch (error) {
+      console.error(`[StorageRepository] Failed to remove key "${key}":`, error)
+    }
+  }
+}
+
+export const storageRepository = new LocalStorageRepository()

--- a/src/frontend/src/utils/storageKeys.tsx
+++ b/src/frontend/src/utils/storageKeys.tsx
@@ -5,4 +5,5 @@ export const STORAGE_KEYS = {
   NOTIFICATIONS: 'app_notification_settings',
   USER_PREFERENCES: 'app_user_preferences',
   ACCESSIBILITY: 'app_accessibility_settings',
+  SILENT_LOGIN_RETRY: 'silent-login-retry',
 } as const


### PR DESCRIPTION
## Purpose

Description...


## Proposal
Closes #58
Problem
Four files (userPreferences.ts, notifications.ts, accessibility.ts, silentLogin.ts) each contained identical try/catch localStorage boilerplate with no shared abstraction. The silent-login-retry key was an unregistered magic string. Changing the storage backend required editing every file.
Approach — Repository pattern (Structural)
Introduced LocalStorageRepository behind an IStorageRepository interface in src/utils/StorageRepository.ts. All inline localStorage.getItem/setItem/removeItem calls in the four consumer files are replaced with storageRepository.load/save/remove. The SILENT_LOGIN_RETRY key is now registered in STORAGE_KEYS.
Note on scope vs. issue description
The issue described Command pattern + scattered calls across UI components. The actual codebase already had centralized stores — the real anti-pattern was duplicated storage boilerplate across those stores with no shared abstraction. The Repository pattern is the correct fit for what actually exists.
Verification

All existing settings persist correctly — the repository delegates to the same localStorage backend
No direct localStorage calls remain outside StorageRepository.ts
Pre-existing 48 type errors are unrelated to this change
Description...

- [] item 1...
- [] item 2...
