### PR TITLE
P3/issue 53 consolidate notification helpers

### DIFF
--- a/src/frontend/src/features/notifications/MainNotificationToast.tsx
+++ b/src/frontend/src/features/notifications/MainNotificationToast.tsx
@@ -5,10 +5,22 @@ import { ChatMessage, isMobileBrowser } from '@livekit/components-core'
 import { useTranslation } from 'react-i18next'
 import { Div } from '@/primitives'
 import { NotificationType } from './NotificationType'
-import { NotificationDuration } from './NotificationDuration'
-import { decodeNotificationDataReceived } from './utils'
+import {
+  decodeNotificationDataReceived,
+  showChatMessageToast,
+  showParticipantJoinedToast,
+  showParticipantMutedToast,
+  showHandRaisedToast,
+  showAlertToast,
+  showRecordingRequestedToast,
+  showPermissionsRemovedToast,
+  closeParticipantToasts,
+  closeAllToasts,
+  closeToastByKey,
+  findHandRaisedToast,
+} from './utils'
 import { useNotificationSound } from '@/features/notifications/hooks/useSoundNotification'
-import { ToastProvider, toastQueue } from './components/ToastProvider'
+import { ToastProvider } from './components/ToastProvider'
 import { WaitingParticipantNotification } from './components/WaitingParticipantNotification'
 import {
   Emoji,
@@ -22,25 +34,17 @@ import {
 export const MainNotificationToast = () => {
   const room = useRoomContext()
   const { triggerNotificationSound } = useNotificationSound()
-
   const [reactions, setReactions] = useState<Reaction[]>([])
   const instanceIdRef = useRef(0)
 
   useEffect(() => {
     const handleChatMessage = (
       chatMessage: ChatMessage,
-      participant?: Participant | undefined
+      participant?: Participant
     ) => {
       if (!participant || participant.isLocal) return
       triggerNotificationSound(NotificationType.MessageReceived)
-      toastQueue.add(
-        {
-          participant: participant,
-          message: chatMessage.message,
-          type: NotificationType.MessageReceived,
-        },
-        { timeout: NotificationDuration.MESSAGE }
-      )
+      showChatMessageToast(participant, chatMessage.message)
     }
     room.on(RoomEvent.ChatMessage, handleChatMessage)
     return () => {
@@ -51,14 +55,7 @@ export const MainNotificationToast = () => {
   const handleEmoji = (emoji: string, participant: Participant) => {
     if (!emoji || !Object.values(Emoji).includes(emoji as Emoji)) return
     const id = instanceIdRef.current++
-    setReactions((prev) => [
-      ...prev,
-      {
-        id,
-        emoji,
-        participant,
-      },
-    ])
+    setReactions((prev) => [...prev, { id, emoji, participant }])
     setTimeout(() => {
       setReactions((prev) => prev.filter((instance) => instance.id !== id))
     }, ANIMATION_DURATION)
@@ -70,21 +67,11 @@ export const MainNotificationToast = () => {
       participant?: RemoteParticipant
     ) => {
       const notification = decodeNotificationDataReceived(payload)
-
       if (!notification) return
 
       switch (notification.type) {
         case NotificationType.ParticipantMuted:
-          if (participant) {
-            toastQueue.add(
-              {
-                participant,
-                type: NotificationType.ParticipantMuted,
-              },
-              { timeout: NotificationDuration.ALERT }
-            )
-          }
-
+          if (participant) showParticipantMutedToast(participant)
           break
         case NotificationType.ReactionReceived:
           if (notification.data?.emoji && participant)
@@ -96,35 +83,16 @@ export const MainNotificationToast = () => {
         case NotificationType.ScreenRecordingStopped:
         case NotificationType.TranscriptionLimitReached:
         case NotificationType.ScreenRecordingLimitReached:
-          toastQueue.add(
-            {
-              participant,
-              type: notification.type,
-            },
-            { timeout: NotificationDuration.ALERT }
-          )
+          showAlertToast(notification.type, participant)
           break
         case NotificationType.TranscriptionRequested:
         case NotificationType.ScreenRecordingRequested:
-          toastQueue.add(
-            {
-              participant,
-              type: notification.type,
-            },
-            { timeout: NotificationDuration.RECORDING_REQUESTED }
-          )
+          showRecordingRequestedToast(notification.type, participant)
           break
         case NotificationType.PermissionsRemoved: {
           const removedSources = notification?.data?.removedSources
           if (!removedSources?.length) break
-          toastQueue.add(
-            {
-              participant,
-              type: notification.type,
-              removedSources: removedSources,
-            },
-            { timeout: NotificationDuration.ALERT }
-          )
+          showPermissionsRemovedToast(participant, removedSources)
           break
         }
         default:
@@ -138,100 +106,56 @@ export const MainNotificationToast = () => {
   }, [room])
 
   useEffect(() => {
-    const showJoinNotification = (participant: Participant) => {
-      if (isMobileBrowser()) {
-        return
-      }
+    const handleParticipantJoined = (participant: Participant) => {
+      if (isMobileBrowser()) return
       triggerNotificationSound(NotificationType.ParticipantJoined)
-      toastQueue.add(
-        {
-          participant,
-          type: NotificationType.ParticipantJoined,
-        },
-        {
-          timeout: NotificationDuration.PARTICIPANT_JOINED,
-        }
-      )
+      showParticipantJoinedToast(participant)
     }
-    room.on(RoomEvent.ParticipantConnected, showJoinNotification)
+    room.on(RoomEvent.ParticipantConnected, handleParticipantJoined)
     return () => {
-      room.off(RoomEvent.ParticipantConnected, showJoinNotification)
+      room.off(RoomEvent.ParticipantConnected, handleParticipantJoined)
     }
   }, [room, triggerNotificationSound])
 
   useEffect(() => {
-    const removeParticipantNotifications = (participant: Participant) => {
-      toastQueue.visibleToasts.forEach((toast) => {
-        if (toast.content.participant === participant) {
-          toastQueue.close(toast.key)
-        }
-      })
-    }
-    room.on(RoomEvent.ParticipantDisconnected, removeParticipantNotifications)
+    room.on(RoomEvent.ParticipantDisconnected, closeParticipantToasts)
     return () => {
-      room.off(
-        RoomEvent.ParticipantDisconnected,
-        removeParticipantNotifications
-      )
+      room.off(RoomEvent.ParticipantDisconnected, closeParticipantToasts)
     }
   }, [room])
 
   useEffect(() => {
-    const handleNotificationReceived = (
+    const handleHandRaise = (
       changedAttributes: Record<string, string>,
       participant: Participant
     ) => {
-      if (!participant) return
-      if (isMobileBrowser()) return
-      if (participant.isLocal) return
-
+      if (!participant || isMobileBrowser() || participant.isLocal) return
       if (!('handRaisedAt' in changedAttributes)) return
 
-      const existingToast = toastQueue.visibleToasts.find(
-        (toast) =>
-          toast.content.participant === participant &&
-          toast.content.type === NotificationType.HandRaised
-      )
+      const existingToast = findHandRaisedToast(participant)
 
       if (existingToast && !changedAttributes?.handRaisedAt) {
-        toastQueue.close(existingToast.key)
+        closeToastByKey(existingToast.key)
         return
       }
-
       if (!existingToast && !!changedAttributes?.handRaisedAt) {
         triggerNotificationSound(NotificationType.HandRaised)
-        toastQueue.add(
-          {
-            participant,
-            type: NotificationType.HandRaised,
-          },
-          { timeout: NotificationDuration.HAND_RAISED }
-        )
+        showHandRaisedToast(participant)
       }
     }
-
-    room.on(RoomEvent.ParticipantAttributesChanged, handleNotificationReceived)
-
+    room.on(RoomEvent.ParticipantAttributesChanged, handleHandRaise)
     return () => {
-      room.off(
-        RoomEvent.ParticipantAttributesChanged,
-        handleNotificationReceived
-      )
+      room.off(RoomEvent.ParticipantAttributesChanged, handleHandRaise)
     }
   }, [room, triggerNotificationSound])
 
   useEffect(() => {
-    const closeAllToasts = () => {
-      toastQueue.visibleToasts.forEach(({ key }) => toastQueue.close(key))
-    }
     room.on(RoomEvent.Disconnected, closeAllToasts)
     return () => {
       room.off(RoomEvent.Disconnected, closeAllToasts)
     }
   }, [room])
 
-  // Without this line, when the component first renders,
-  // the 'notifications' namespace might not be loaded yet
   useTranslation(['notifications'])
 
   return (

--- a/src/frontend/src/features/notifications/utils.ts
+++ b/src/frontend/src/features/notifications/utils.ts
@@ -10,14 +10,8 @@ export const showLowerHandToast = (
   onClose: () => void
 ) => {
   toastQueue.add(
-    {
-      participant,
-      type: NotificationType.LowerHand,
-    },
-    {
-      timeout: NotificationDuration.LOWER_HAND,
-      onClose,
-    }
+    { participant, type: NotificationType.LowerHand },
+    { timeout: NotificationDuration.LOWER_HAND, onClose }
   )
 }
 
@@ -27,6 +21,94 @@ export const closeLowerHandToasts = () => {
       toastQueue.close(toast.key)
     }
   })
+}
+
+export const showChatMessageToast = (
+  participant: Participant,
+  message: string
+) => {
+  toastQueue.add(
+    { participant, message, type: NotificationType.MessageReceived },
+    { timeout: NotificationDuration.MESSAGE }
+  )
+}
+
+export const showParticipantJoinedToast = (participant: Participant) => {
+  toastQueue.add(
+    { participant, type: NotificationType.ParticipantJoined },
+    { timeout: NotificationDuration.PARTICIPANT_JOINED }
+  )
+}
+
+export const showParticipantMutedToast = (participant: Participant) => {
+  toastQueue.add(
+    { participant, type: NotificationType.ParticipantMuted },
+    { timeout: NotificationDuration.ALERT }
+  )
+}
+
+export const showHandRaisedToast = (participant: Participant) => {
+  toastQueue.add(
+    { participant, type: NotificationType.HandRaised },
+    { timeout: NotificationDuration.HAND_RAISED }
+  )
+}
+
+export const showAlertToast = (
+  type: NotificationType,
+  participant?: Participant
+) => {
+  toastQueue.add({ participant, type }, { timeout: NotificationDuration.ALERT })
+}
+
+export const showRecordingRequestedToast = (
+  type: NotificationType,
+  participant?: Participant
+) => {
+  toastQueue.add(
+    { participant, type },
+    { timeout: NotificationDuration.RECORDING_REQUESTED }
+  )
+}
+
+export const showPermissionsRemovedToast = (
+  participant: Participant | undefined,
+  removedSources: string[]
+) => {
+  toastQueue.add(
+    { participant, type: NotificationType.PermissionsRemoved, removedSources },
+    { timeout: NotificationDuration.ALERT }
+  )
+}
+
+export const closeParticipantToasts = (participant: Participant) => {
+  toastQueue.visibleToasts.forEach((toast) => {
+    if (toast.content.participant === participant) {
+      toastQueue.close(toast.key)
+    }
+  })
+}
+
+export const closeAllToasts = () => {
+  toastQueue.visibleToasts.forEach(({ key }) => toastQueue.close(key))
+}
+
+export const findHandRaisedToast = (participant: Participant) => {
+  return toastQueue.visibleToasts.find(
+    (toast) =>
+      toast.content.participant === participant &&
+      toast.content.type === NotificationType.HandRaised
+  )
+}
+
+export const notifyRecordingSaveInProgress = (
+  mode: RecordingMode,
+  participant: Participant
+) => {
+  toastQueue.add(
+    { participant, mode, type: NotificationType.RecordingSaving },
+    { timeout: NotificationDuration.RECORDING_SAVING }
+  )
 }
 
 export const decodeNotificationDataReceived = (
@@ -41,26 +123,13 @@ export const decodeNotificationDataReceived = (
     if (!jsonString || typeof jsonString !== 'string') {
       throw new Error('Invalid decoded content')
     }
-    // Parse with additional validation if needed
-    const parsed = JSON.parse(jsonString)
-    return parsed as NotificationPayload
+    return JSON.parse(jsonString) as NotificationPayload
   } catch (error) {
-    // Handle errors appropriately for your application
     console.error('Failed to decode notification payload:', error)
     return
   }
 }
 
-export const notifyRecordingSaveInProgress = (
-  mode: RecordingMode,
-  participant: Participant
-) => {
-  toastQueue.add(
-    {
-      participant,
-      mode,
-      type: NotificationType.RecordingSaving,
-    },
-    { timeout: NotificationDuration.RECORDING_SAVING }
-  )
+export const closeToastByKey = (key: string) => {
+  toastQueue.close(key)
 }


### PR DESCRIPTION
## Problem
MainNotificationToast.tsx contained 7 inline toastQueue.add() calls
scattered across 6 useEffect hooks. Each notification type (chat message,
participant joined, muted, hand raised, recording events, permissions)
had its own hardcoded toastQueue.add() call with different shapes and
durations. Adding a new notification type required editing this file
directly and knowing the exact toastQueue.add() signature.

Closes #53

## Design Pattern: Observer / Facade
Extract all inline toastQueue.add() calls into named helper functions
in utils.ts. MainNotificationToast now only wires room events to
notification helpers — it no longer owns display logic.

## Files changed
- `notifications/utils.ts` — added 8 named helper functions:
  showChatMessageToast, showParticipantJoinedToast,
  showParticipantMutedToast, showHandRaisedToast, showAlertToast,
  showRecordingRequestedToast, showPermissionsRemovedToast,
  closeParticipantToasts, closeAllToasts, closeToastByKey,
  findHandRaisedToast
- `notifications/MainNotificationToast.tsx` — replaced all inline
  toastQueue.add() calls with named helper imports. No longer imports
  toastQueue directly.

## Before / After
Before: Adding a new notification type required editing
MainNotificationToast.tsx and knowing toastQueue internals.
After: Adding a new notification type = add one helper to utils.ts,
call it from MainNotificationToast. Zero knowledge of toastQueue needed.

## Verification
- Manually verified: chat messages, participant join, hand raise,
  mute notifications all trigger correctly
- MainNotificationToast no longer imports toastQueue directly
- All existing notification behaviors preserved